### PR TITLE
show loading file path on console

### DIFF
--- a/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
@@ -3,7 +3,7 @@
    :name com.github.clojure_repl.intellij.action.LoadFile
    :extends com.intellij.openapi.actionSystem.AnAction)
   (:require
-   [com.github.clojure-repl.intellij.configuration.repl-client :as repl-client])
+   [com.github.clojure-repl.intellij.nrepl :as nrepl])
   (:import
    [com.intellij.openapi.actionSystem CommonDataKeys]
    [com.intellij.openapi.actionSystem AnActionEvent]
@@ -14,4 +14,4 @@
 (defn -actionPerformed [_ ^AnActionEvent event]
   (when-let [vf ^VirtualFile (.getData event CommonDataKeys/VIRTUAL_FILE)]
     (let [path (.getCanonicalPath vf)]
-      (repl-client/load-file path))))
+      (nrepl/load-file path))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
@@ -3,7 +3,7 @@
    :name com.github.clojure_repl.intellij.action.LoadFile
    :extends com.intellij.openapi.actionSystem.AnAction)
   (:require
-   [com.github.clojure-repl.intellij.nrepl :as nrepl])
+   [com.github.clojure-repl.intellij.configuration.repl-client :as repl-client])
   (:import
    [com.intellij.openapi.actionSystem CommonDataKeys]
    [com.intellij.openapi.actionSystem AnActionEvent]
@@ -14,4 +14,4 @@
 (defn -actionPerformed [_ ^AnActionEvent event]
   (when-let [vf ^VirtualFile (.getData event CommonDataKeys/VIRTUAL_FILE)]
     (let [path (.getCanonicalPath vf)]
-      (nrepl/load-file path))))
+      (repl-client/load-file path))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
@@ -14,4 +14,4 @@
 (defn -actionPerformed [_ ^AnActionEvent event]
   (when-let [vf ^VirtualFile (.getData event CommonDataKeys/VIRTUAL_FILE)]
     (let [path (.getCanonicalPath vf)]
-      (nrepl/load-file path))))
+      (nrepl/load-file (-> event .getProject .getName) path))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/repl_client.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/repl_client.clj
@@ -149,7 +149,7 @@
 
          (resetEditorFrom [_ configuration-base]
            (setup-settings configuration-base)
-           (reset-editor-from-settings configuration-base))))
+           (reset-editor-from-settings))))
 
      (getState [executor ^ExecutionEnvironment env]
        (setup-settings this)
@@ -158,3 +158,8 @@
            (build-console-view))
          (startProcess []
            (start-process)))))))
+
+(defn load-file [file]
+  (let [console (:console @current-repl*)]
+    (ui.repl/append-text console (str "\nLoading file " file "...\n"))
+    (nrepl/load-file file)))

--- a/src/main/clojure/com/github/clojure_repl/intellij/db.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/db.clj
@@ -4,5 +4,5 @@
                                     :ns "user"}
                     :settings {:nrepl-port nil
                                :nrepl-host "localhost"}
-                    :on-repl-file-loaded-fns []}
-                   :ops {}))
+                    :on-repl-file-loaded-fns []
+                    :ops {}}))

--- a/src/main/clojure/com/github/clojure_repl/intellij/db.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/db.clj
@@ -4,4 +4,5 @@
                                     :ns "user"}
                     :settings {:nrepl-port nil
                                :nrepl-host "localhost"}
-                   :ops {}}))
+                    :on-repl-file-loaded-fns []}
+                   :ops {}))

--- a/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
@@ -28,7 +28,9 @@
   (send-message {:op "ls-sessions"}))
 
 (defn load-file [file]
-  (send-message {:op "load-file" :file (slurp file)}))
+  (send-message {:op "load-file" :file (slurp file)})
+  (doseq [callback (:on-repl-file-loaded-fns @db/db*)]
+    (callback file)))
 
 (defn describe []
   (send-message {:op "describe"}))

--- a/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
@@ -27,10 +27,11 @@
 (defn list-sessions []
   (send-message {:op "ls-sessions"}))
 
-(defn load-file [file]
+(defn load-file [project file]
   (send-message {:op "load-file" :file (slurp file)})
-  (doseq [callback (:on-repl-file-loaded-fns @db/db*)]
-    (callback file)))
+  (doseq [fns (:on-repl-file-loaded-fns @db/db*)]
+    (when (= (:project fns) project)
+      ((:fn fns) file))))
 
 (defn describe []
   (send-message {:op "describe"}))

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
@@ -16,6 +16,12 @@
 
 (defonce ^:private console-state* (atom {:last-output nil}))
 
+(defn append-text [console text]
+  (let [repl-content (seesaw/select console [:#repl-content])
+        ns-text (str "\n" (-> @db/db* :current-nrepl :ns) "> ")]
+    (.append ^JTextArea repl-content (str text ns-text))))
+
+
 (defn ^:private extract-code-to-eval [repl-content-text]
   (or (some-> (re-find code-to-eval-regexp repl-content-text)
               last
@@ -90,8 +96,3 @@
     (swap! console-state* assoc :status :closed)
     (seesaw/config! repl-content :editable? false)
     (.append ^JTextArea repl-content (format "\n*** Closed on %s ***" (.format time-formatter (java.time.LocalDateTime/now))))))
-
-(defn append-text [console text]
-  (let [repl-content (seesaw/select console [:#repl-content])
-        ns-text (str "\n" (-> @db/db* :current-nrepl :ns) "> ")]
-    (.append ^JTextArea repl-content (str text ns-text))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
@@ -90,3 +90,8 @@
     (swap! console-state* assoc :status :closed)
     (seesaw/config! repl-content :editable? false)
     (.append ^JTextArea repl-content (format "\n*** Closed on %s ***" (.format time-formatter (java.time.LocalDateTime/now))))))
+
+(defn append-text [console text]
+  (let [repl-content (seesaw/select console [:#repl-content])
+        ns-text (str "\n" (-> @db/db* :current-nrepl :ns) "> ")]
+    (.append ^JTextArea repl-content (str text ns-text))))

--- a/src/main/kotlin/run-configuration-options.kt
+++ b/src/main/kotlin/run-configuration-options.kt
@@ -6,6 +6,7 @@ class ReplClientRunOptions : RunConfigurationOptions() {
 
     private var nreplHostOption = string("").provideDelegate(this, "nreplHost")
     private var nreplPortOption = string("").provideDelegate(this, "nreplPort")
+    private var projectOption = string("").provideDelegate(this, "project")
 
     var nreplHost: String
         get() = nreplHostOption.getValue(this) ?: ""
@@ -14,4 +15,8 @@ class ReplClientRunOptions : RunConfigurationOptions() {
     var nreplPort: String
         get() = nreplPortOption.getValue(this) ?: ""
         set(value) = nreplPortOption.setValue(this, value)
+
+    var project: String
+        get() = projectOption.getValue(this) ?: ""
+        set(value) = projectOption.setValue(this, value)
 }


### PR DESCRIPTION
When using `Load File REPL` action, we do not have any information about the file. This PR aims to show to the user in the console the file that is being loaded.
Added project field to configuration, uses it to related actions and repl.

It does not cover error cases. For this I created another issue: #22 

<img width="1103" alt="Screenshot 2023-10-23 at 10 27 04" src="https://github.com/afucher/clojure-repl-intellij/assets/3756185/5d2161a5-2a08-4146-b290-2e6eeb0bc3b8">
<img width="1038" alt="Screenshot 2023-10-25 at 20 23 52" src="https://github.com/afucher/clojure-repl-intellij/assets/3756185/3eb97bc9-5554-48c5-988d-41acb4b8b33c">
