### PR TITLE
fix difference between line start number in editor and rewrite-clj

### DIFF
--- a/src/main/clojure/com/github/clojure_repl/intellij/action/eval_last_sexp.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/eval_last_sexp.clj
@@ -23,7 +23,7 @@
           [row col] (editor/editor->cursor-position editor)
           text (.getText (.getDocument editor))
           root-zloc (z/of-string text)
-          zloc (parser/find-at-pos root-zloc row col)
+          zloc (parser/find-at-pos root-zloc (inc row) col)
           code (z/string zloc)
           {:keys [value err]} (nrepl/eval {:code code})]
       (if err


### PR DESCRIPTION
IntelliJ editor consider the first line as 0, but rewrite-clj expect the first line to be 1.
Leave the editor ns without inc, because I think that it should be just a pure proxy for the IntelliJ editors API.

![Screenshot 2023-10-27 at 17 04 43](https://github.com/afucher/clojure-repl-intellij/assets/3756185/6d28eebd-a555-4e95-b4c8-453aca3aa7d1)
![Screenshot 2023-10-27 at 17 04 51](https://github.com/afucher/clojure-repl-intellij/assets/3756185/910abf26-4e8e-403a-93e7-e986694710a6)
![Screenshot 2023-10-27 at 17 04 59](https://github.com/afucher/clojure-repl-intellij/assets/3756185/b43a2cb4-173a-48f7-ac7a-51242d6e7070)
