### PR TITLE
Fix duplicated output to repl + other improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix repl output duplicated.
+
 ## 0.1.2
 
 ## 0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix repl output duplicated.
+- Clear repl state on repl disconnection.
 
 ## 0.1.2
 

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/eval_last_sexp.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/eval_last_sexp.clj
@@ -7,6 +7,7 @@
    [com.github.clojure-repl.intellij.editor :as editor]
    [com.github.clojure-repl.intellij.nrepl :as nrepl]
    [com.github.clojure-repl.intellij.parser :as parser]
+   [com.github.clojure-repl.intellij.ui.repl-hint :as ui.repl-hint]
    [rewrite-clj.zip :as z])
   (:import
    [com.intellij.codeInsight.hint HintManager]
@@ -28,6 +29,6 @@
           code (z/string zloc)
           {:keys [value err]} (nrepl/eval {:project project :code code})]
       (if err
-        (.showErrorHint (HintManager/getInstance) editor (str "=> " err) (HintManager/RIGHT))
-        (.showInformationHint (HintManager/getInstance) editor (str "=> " (or value "nil")) (HintManager/RIGHT))))
+        (ui.repl-hint/show-error err editor)
+        (ui.repl-hint/show-info value editor)))
     (.showErrorHint (HintManager/getInstance) (.getData event CommonDataKeys/EDITOR_EVEN_IF_INACTIVE) "No REPL connected" (HintManager/RIGHT))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
@@ -3,15 +3,19 @@
    :name com.github.clojure_repl.intellij.action.LoadFile
    :extends com.intellij.openapi.actionSystem.AnAction)
   (:require
-   [com.github.clojure-repl.intellij.nrepl :as nrepl])
+   [com.github.clojure-repl.intellij.nrepl :as nrepl]
+   [com.github.clojure-repl.intellij.ui.repl-hint :as ui.repl-hint])
   (:import
    [com.intellij.openapi.actionSystem CommonDataKeys]
    [com.intellij.openapi.actionSystem AnActionEvent]
+   [com.intellij.openapi.editor Editor]
    [com.intellij.openapi.vfs VirtualFile]))
 
 (set! *warn-on-reflection* true)
 
 (defn -actionPerformed [_ ^AnActionEvent event]
   (when-let [vf ^VirtualFile (.getData event CommonDataKeys/VIRTUAL_FILE)]
-    (let [path (.getCanonicalPath vf)]
-      (nrepl/load-file (-> event .getProject .getName) path))))
+    (let [editor ^Editor (.getData event CommonDataKeys/EDITOR_EVEN_IF_INACTIVE)
+          path (.getCanonicalPath vf)]
+      (nrepl/load-file (-> event .getProject .getName) path)
+      (ui.repl-hint/show-info (str "Loaded file " path) editor))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/switch_ns.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/switch_ns.clj
@@ -6,6 +6,7 @@
    [com.github.clojure-repl.intellij.db :as db]
    [com.github.clojure-repl.intellij.nrepl :as nrepl]
    [com.github.clojure-repl.intellij.parser :as parser]
+   [com.github.clojure-repl.intellij.ui.repl-hint :as ui.repl-hint]
    [rewrite-clj.zip :as z])
   (:import
    [com.intellij.codeInsight.hint HintManager]
@@ -26,6 +27,6 @@
           namespace (z/string zloc)
           {:keys [value err]} (nrepl/eval {:project project :code (format "(in-ns '%s)" namespace)})]
       (if err
-        (.showErrorHint (HintManager/getInstance) editor (str "=> " err) (HintManager/RIGHT))
-        (.showInformationHint (HintManager/getInstance) editor (str "=> " (or value "nil")) (HintManager/RIGHT))))
+        (ui.repl-hint/show-error err editor)
+        (ui.repl-hint/show-info value editor)))
     (.showErrorHint (HintManager/getInstance) (.getData event CommonDataKeys/EDITOR_EVEN_IF_INACTIVE) "No REPL connected" (HintManager/RIGHT))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/repl_client.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/repl_client.clj
@@ -166,10 +166,12 @@
            (setup-settings configuration-base)
            (reset-editor-from-settings))))
 
-     (getState [executor ^ExecutionEnvironment env]
-       (setup-settings this)
-       (proxy [CommandLineState] [env]
-         (createConsole [_]
-           (build-console-view project))
-         (startProcess []
-           (start-process project)))))))
+     (getState
+       ([])
+       ([executor ^ExecutionEnvironment env]
+        (setup-settings this)
+        (proxy [CommandLineState] [env]
+          (createConsole [_]
+            (build-console-view project))
+          (startProcess []
+            (start-process project))))))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/repl_client.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/repl_client.clj
@@ -48,6 +48,11 @@
 (defn -getHelpTopic [_] "Clojure REPL")
 (defn -getOptionsClass [_] ReplClientRunOptions)
 
+(defn ^:private close-repl []
+  (ui.repl/close-console (:console @current-repl*))
+  (reset! current-repl* initial-current-repl)
+  (swap! db/db* assoc :current-nrepl nil))
+
 (defn ^:private build-editor-view []
   (mig/mig-panel
    :border (IdeBorderFactory/createTitledBorder "NREPL connection")
@@ -113,8 +118,7 @@
     (swap! current-repl* assoc :handler handler)
     (.addProcessListener handler
                          (proxy+ [] ProcessListener
-                           (processWillTerminate [_ _ _]
-                             (ui.repl/close-console (:console @current-repl*)))))
+                           (processWillTerminate [_ _ _] (close-repl))))
     handler))
 
 (defn ^:private apply-editor-to [^RunConfigurationBase configuration-base]

--- a/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
@@ -33,9 +33,6 @@
 (defn clone-session []
   (swap! db/db* assoc-in [:current-nrepl :session-id] (:new-session (send-message {:op "clone"}))))
 
-(defn list-sessions []
-  (send-message {:op "ls-sessions"}))
-
 (defn load-file [project file]
   (send-message {:op "load-file" :file (slurp file)})
   (doseq [fns (:on-repl-file-loaded-fns @db/db*)]

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
@@ -16,12 +16,6 @@
 
 (defonce ^:private console-state* (atom {:last-output nil}))
 
-(defn append-text [console text]
-  (let [repl-content (seesaw/select console [:#repl-content])
-        ns-text (str "\n" (-> @db/db* :current-nrepl :ns) "> ")]
-    (.append ^JTextArea repl-content (str text ns-text))))
-
-
 (defn ^:private extract-code-to-eval [repl-content-text]
   (or (some-> (re-find code-to-eval-regexp repl-content-text)
               last

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/repl_hint.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/repl_hint.clj
@@ -1,0 +1,14 @@
+(ns com.github.clojure-repl.intellij.ui.repl-hint
+  (:import
+   [com.intellij.codeInsight.hint HintManager]
+   [com.intellij.openapi.editor Editor]))
+
+(set! *warn-on-reflection* true)
+
+(defn show-info
+  [value ^Editor editor]
+  (.showInformationHint (HintManager/getInstance) editor (str "=> " (or value "nil")) (HintManager/RIGHT)))
+
+(defn show-error
+  [error ^Editor editor]
+  (.showErrorHint (HintManager/getInstance) editor (str "=> " error) (HintManager/RIGHT)))

--- a/src/main/kotlin/run-configuration-options.kt
+++ b/src/main/kotlin/run-configuration-options.kt
@@ -2,7 +2,7 @@ package com.github.clojure_repl.intellij.configuration
 
 import com.intellij.execution.configurations.RunConfigurationOptions
 
-class ReplClientRunOptions : RunConfigurationOptions() {
+class ReplRemoteRunOptions : RunConfigurationOptions() {
 
     private var nreplHostOption = string("").provideDelegate(this, "nreplHost")
     private var nreplPortOption = string("").provideDelegate(this, "nreplPort")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
     <depends>com.intellij.modules.platform</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <configurationType implementation="com.github.clojure_repl.intellij.configuration.ReplClientRunConfigurationType"/>
+        <configurationType implementation="com.github.clojure_repl.intellij.configuration.ReplRunConfigurationType"/>
         <postStartupActivity implementation="com.github.ericdallo.clj4intellij.extension.NREPLStartup"/>
     </extensions>
 


### PR DESCRIPTION
Fixes #34

- Fix REPL output from #34
- Clear REPL state on disconnection, to avoid allow eval things even with repl disconnected
- Fix an exception that happens after some time using the plugin
- Refactor: prepare ConfigurationType to support multiple ConfigurationFactories in the future