### PR TITLE
Segregate db by project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Improve success test report message UI.
+- Support multiple opened projects. #51
+- Fix eval not using same session as load-file. #52
 
 ## 0.1.7
 

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/switch_ns.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/switch_ns.clj
@@ -18,14 +18,14 @@
 (defn -actionPerformed [_ ^AnActionEvent event]
   ;; TODO change for listeners here or a better way to know which repl is related to current opened file
   (when-let [editor ^Editor (.getData event CommonDataKeys/EDITOR_EVEN_IF_INACTIVE)]
-    (if (-> @db/db* :current-nrepl :session-id)
-      (let [project (.getData event CommonDataKeys/PROJECT)
-            text (.getText (.getDocument editor))
-            root-zloc (z/of-string text)
-            zloc (parser/find-namespace root-zloc)
-            namespace (z/string zloc)
-            {:keys [value err]} (nrepl/eval {:project project :code (format "(in-ns '%s)" namespace)})]
-        (if err
-          (ui.hint/show-repl-error :message err :editor editor)
-          (ui.hint/show-repl-info :message value :editor editor)))
-      (ui.hint/show-error :message "No REPL connected" :editor editor))))
+    (let [project (.getData event CommonDataKeys/PROJECT)]
+      (if (db/get-in project [:current-nrepl :session-id])
+        (let [text (.getText (.getDocument editor))
+              root-zloc (z/of-string text)
+              zloc (parser/find-namespace root-zloc)
+              namespace (z/string zloc)
+              {:keys [value err]} (nrepl/eval {:project project :code (format "(in-ns '%s)" namespace) :ns namespace})]
+          (if err
+            (ui.hint/show-repl-error :message err :editor editor)
+            (ui.hint/show-repl-info :message value :editor editor)))
+        (ui.hint/show-error :message "No REPL connected" :editor editor)))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
@@ -8,7 +8,8 @@
    [com.intellij.execution.ui ConsoleView]
    [com.intellij.ide.plugins PluginManagerCore]
    [com.intellij.openapi.actionSystem AnAction]
-   [com.intellij.openapi.extensions PluginId]))
+   [com.intellij.openapi.extensions PluginId]
+   [com.intellij.openapi.project Project]))
 
 (set! *warn-on-reflection* true)
 
@@ -16,11 +17,11 @@
                               :console nil}))
 (defonce editor-view* (atom nil))
 
-(defn ^:private initial-repl-text []
-  (let [{:keys [clojure java nrepl]} (-> @db/db* :current-nrepl :versions)]
+(defn ^:private initial-repl-text [project]
+  (let [{:keys [clojure java nrepl]} (db/get-in project [:current-nrepl :versions])]
     (str (format ";; Connected to nREPL server - nrepl://%s:%s\n"
-                 (-> @db/db* :settings :nrepl-host)
-                 (-> @db/db* :settings :nrepl-port))
+                 (db/get-in project [:settings :nrepl-host])
+                 (db/get-in project [:settings :nrepl-port]))
          (format ";; Clojure REPL Intellij %s\n"
                  (.getVersion
                   (PluginManagerCore/getPlugin (PluginId/getId "com.github.clojure-repl"))))
@@ -33,6 +34,7 @@
   (reset! current-repl* {:handler nil
                          :console nil})
   (swap! current-repl* assoc :console (ui.repl/build-console
+                                       project
                                        {:on-eval (fn [code]
                                                    (nrepl/eval {:project project :code code}))}))
   (ui.repl/append-text (:console @current-repl*) loading-text)
@@ -56,16 +58,16 @@
     (createConsoleActions [_] (into-array AnAction []))
     (allowHeavyFilters [_])))
 
-(defn repl-disconnected []
+(defn repl-disconnected [^Project project]
   (ui.repl/close-console (:console @current-repl*))
   (reset! current-repl* {:handler nil
                          :console nil})
-  (swap! db/db* assoc :current-nrepl nil))
+  (db/assoc-in project [:current-nrepl] nil))
 
 (defn repl-started [project extra-initial-text]
-  (nrepl/clone-session)
+  (nrepl/clone-session project)
   (nrepl/eval {:project project :code "*ns*"})
-  (let [description (nrepl/describe)]
-    (swap! db/db* assoc-in [:current-nrepl :ops] (:ops description))
-    (swap! db/db* assoc-in [:current-nrepl :versions] (:versions description))
-    (ui.repl/set-initial-text (:console @current-repl*) (str (initial-repl-text) extra-initial-text))))
+  (let [description (nrepl/describe project)]
+    (db/assoc-in project [:current-nrepl :ops] (:ops description))
+    (db/assoc-in project [:current-nrepl :versions] (:versions description))
+    (ui.repl/set-initial-text project (:console @current-repl*) (str (initial-repl-text project) extra-initial-text))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/db.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/db.clj
@@ -1,12 +1,47 @@
-(ns com.github.clojure-repl.intellij.db)
+(ns com.github.clojure-repl.intellij.db
+  (:refer-clojure :exclude [get-in assoc-in update-in])
+  (:require
+   [com.github.clojure-repl.intellij.db :as db])
+  (:import
+   [com.intellij.openapi.project Project]))
 
-(defonce db* (atom {:current-nrepl {:session-id nil
-                                    :ns "user"}
-                    :settings {:nrepl-port nil
-                               :nrepl-host "localhost"
-                               :remote-repl-mode :manual-config}
-                    :on-repl-file-loaded-fns []
-                    :on-repl-evaluated-fns []
-                    :on-test-failed-fns []
-                    :on-test-succeeded-fns []
-                    :ops {}}))
+(set! *warn-on-reflection* true)
+
+(def ^:private empty-project
+  {:project nil
+   :current-nrepl {:session-id nil
+                   :ns "user"}
+   :settings {:nrepl-port nil
+              :nrepl-host "localhost"
+              :remote-repl-mode :manual-config}
+   :on-repl-file-loaded-fns []
+   :on-repl-evaluated-fns []
+   :ops {}})
+
+(defonce ^:private db* (atom {:projects {}
+                              :on-test-failed-fns-by-key {}
+                              :on-test-succeeded-fns-by-key {}}))
+
+(defn get-in
+  ([project fields]
+   (get-in project fields nil))
+  ([^Project project fields default]
+   (clojure.core/get-in @db* (concat [:projects (.getBasePath project)] fields) default)))
+
+(defn global-get-in
+  ([fields]
+   (global-get-in fields nil))
+  ([fields default]
+   (clojure.core/get-in @db* fields default)))
+
+(defn assoc-in [^Project project fields value]
+  (swap! db* clojure.core/assoc-in (concat [:projects (.getBasePath project)] fields) value))
+
+(defn global-update-in [fields value]
+  (swap! db* clojure.core/update-in fields value))
+
+(defn init-db-for-project [^Project project]
+  (swap! db* update :projects (fn [projects]
+                                (if (clojure.core/get projects (.getBasePath project))
+                                  projects
+                                  (assoc projects (.getBasePath project) (assoc empty-project :project project))))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/extension/startup.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/extension/startup.clj
@@ -1,0 +1,14 @@
+(ns com.github.clojure-repl.intellij.extension.startup
+  (:gen-class
+   :name com.github.clojure_repl.intellij.extension.Startup
+   :implements [com.intellij.openapi.startup.StartupActivity
+                com.intellij.openapi.project.DumbAware])
+  (:require
+   [com.github.clojure-repl.intellij.db :as db])
+  (:import
+   [com.intellij.openapi.project Project]))
+
+(set! *warn-on-reflection* true)
+
+(defn -runActivity [_this ^Project project]
+  (db/init-db-for-project project))

--- a/src/main/clojure/com/github/clojure_repl/intellij/tests.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/tests.clj
@@ -16,47 +16,51 @@
 (set! *warn-on-reflection* true)
 
 (defn ^:private run [^Editor editor ns tests]
-  (if-not (-> @db/db* :current-nrepl :session-id)
-    (ui.hint/show-error :message "No REPL connected" :editor editor)
-    ;; TODO save last result and summary
-    (tasks/run-background-task!
-     (.getProject editor)
-     "REPL: Running test"
-     (fn [_indicator]
-       (nrepl/run-tests
-        {:ns ns
-         :tests tests
-         :on-ns-not-found (fn [ns]
-                            (app-manager/invoke-later!
-                             {:invoke-fn
-                              (fn []
-                                (ui.hint/show-error :message (format "No namespace '%s' found" ns) :editor editor))}))
-         :on-out (fn [out]
-                   (ui.repl/append-result-text (:console @config.factory.base/current-repl*) out))
-         :on-err (fn [err]
-                   (ui.repl/append-result-text (:console @config.factory.base/current-repl*) err))
-         :on-failed (fn [result]
+  (let [project (.getProject editor)]
+    (if-not (db/get-in project [:current-nrepl :session-id])
+      (ui.hint/show-error :message "No REPL connected" :editor editor)
+      ;; TODO save last result and summary
+      (tasks/run-background-task!
+       project
+       "REPL: Running test"
+       (fn [_indicator]
+         (nrepl/run-tests
+          project
+          {:ns ns
+           :tests tests
+           :on-ns-not-found (fn [ns]
+                              (app-manager/invoke-later!
+                               {:invoke-fn
+                                (fn []
+                                  (ui.hint/show-error :message (format "No namespace '%s' found" ns) :editor editor))}))
+           :on-out (fn [out]
+                     (ui.repl/append-result-text project (:console @config.factory.base/current-repl*) out))
+           :on-err (fn [err]
+                     (ui.repl/append-result-text project (:console @config.factory.base/current-repl*) err))
+           :on-failed (fn [result]
                         ;; TODO highlight errors on editor
-                      (doseq [fns (:on-test-failed-fns @db/db*)]
-                        (fns result)))
-         :on-succeeded (fn [{{:keys [ns test var fail error]} :summary results :results elapsed-time :elapsed-time :as response}]
-                         (app-manager/invoke-later!
-                          {:invoke-fn
-                           (fn []
-                             (if (empty? results)
-                               (ui.hint/show-info :message "No assertions (or no tests) were run. Did you forget to use `is' in your tests?\n" :editor editor)
-                               (ui.hint/show-success :message (format "%s: Ran %s assertions, in %s test functions. %s failures, %s errors%s\n"
-                                                                      (if (= 1 ns)
-                                                                        (name (ffirst results))
-                                                                        (str ns " namespaces"))
-                                                                      test
-                                                                      var
-                                                                      fail
-                                                                      error
-                                                                      (or (some->> (:ms elapsed-time) (format " in %s ms"))
-                                                                          ".")) :editor editor))
-                             (doseq [fns (:on-test-succeeded-fns @db/db*)]
-                               (fns response)))}))})))))
+                        (doseq [[key fns] (db/global-get-in [:on-test-failed-fns-by-key])]
+                          (doseq [fn fns]
+                            (fn project key result))))
+           :on-succeeded (fn [{{:keys [ns test var fail error]} :summary results :results elapsed-time :elapsed-time :as response}]
+                           (app-manager/invoke-later!
+                            {:invoke-fn
+                             (fn []
+                               (if (empty? results)
+                                 (ui.hint/show-info :message "No assertions (or no tests) were run. Did you forget to use `is' in your tests?\n" :editor editor)
+                                 (ui.hint/show-success :message (format "%s: Ran %s assertions, in %s test functions. %s failures, %s errors%s\n"
+                                                                        (if (= 1 ns)
+                                                                          (name (ffirst results))
+                                                                          (str ns " namespaces"))
+                                                                        test
+                                                                        var
+                                                                        fail
+                                                                        error
+                                                                        (or (some->> (:ms elapsed-time) (format " in %s ms"))
+                                                                            ".")) :editor editor))
+                               (doseq [[key fns] (db/global-get-in [:on-test-succeeded-fns-by-key])]
+                                 (doseq [fn fns]
+                                   (fn project key response))))}))}))))))
 
 (defn run-at-cursor [^Editor editor]
   (let [text (.getText (.getDocument editor))

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,6 +8,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <configurationType implementation="com.github.clojure_repl.intellij.configuration.ReplRunConfigurationType"/>
         <postStartupActivity implementation="com.github.ericdallo.clj4intellij.extension.NREPLStartup"/>
+        <postStartupActivity implementation="com.github.clojure_repl.intellij.extension.Startup"/>
         <toolWindow id="Clojure test summary" secondary="true" icon="com.github.clojure_repl.intellij.Icons.CLOJURE_REPL" anchor="right"
                     factoryClass="com.github.clojure_repl.intellij.tool_window.ReplTestToolWindow"/>
         <codeInsight.lineMarkerProvider language="clojure" implementationClass="com.github.clojure_repl.intellij.extension.RunTestLineMarkerProvider"/>


### PR DESCRIPTION
Fixes #51
Fixes #52

- Makes access to db* only possible passing a project
- fix eval to use the correct ns to work with load-file

## how to test

- open project-1, spawn a local or remote repl
- test eval / load-file / switch-ns / tests 
- open project-2, spawn a local or remote repl
- test eval / load-file / switch-ns / tests on that other project