### PR TITLE
Move other atoms to db

### DIFF
--- a/src/main/clojure/com/github/clojure_repl/intellij/action/eval_last_sexp.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/eval_last_sexp.clj
@@ -3,7 +3,6 @@
    :name com.github.clojure_repl.intellij.action.EvalLastSexp
    :extends com.intellij.openapi.actionSystem.AnAction)
   (:require
-   [com.github.clojure-repl.intellij.configuration.factory.base :as config.factory.base]
    [com.github.clojure-repl.intellij.db :as db]
    [com.github.clojure-repl.intellij.nrepl :as nrepl]
    [com.github.clojure-repl.intellij.parser :as parser]
@@ -39,7 +38,7 @@
               ;; TODO how we can avoid coupling config.repl ns with this?
               ;; maybe have a listener only for stdout?
              (when out
-               (ui.repl/append-result-text project (:console @config.factory.base/current-repl*) out))
+               (ui.repl/append-result-text project (db/get-in project [:console :ui]) out))
              (app-manager/invoke-later!
               {:invoke-fn (fn []
                             (if err

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
@@ -4,7 +4,6 @@
    :extends com.intellij.openapi.actionSystem.AnAction)
   (:require
    [clojure.java.io :as io]
-   [com.github.clojure-repl.intellij.configuration.factory.base :as config.factory.base]
    [com.github.clojure-repl.intellij.db :as db]
    [com.github.clojure-repl.intellij.nrepl :as nrepl]
    [com.github.clojure-repl.intellij.ui.hint :as ui.hint]
@@ -34,6 +33,6 @@
                (app-manager/invoke-later!
                 {:invoke-fn (fn []
                               (when err
-                                (ui.repl/append-result-text project (:console @config.factory.base/current-repl*) err))
+                                (ui.repl/append-result-text project (db/get-in project [:console :ui]) err))
                               (ui.hint/show-repl-info :message (str "Loaded file " path) :editor editor))}))))
           (ui.hint/show-error :message "No REPL connected" :editor editor))))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/db.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/db.clj
@@ -9,6 +9,12 @@
 
 (def ^:private empty-project
   {:project nil
+   :console {:state {:last-output nil
+                     :initial-text nil
+                     :status nil}
+             :process-handler nil
+             :ui nil}
+   :run-configuration {:ui nil}
    :current-nrepl {:session-id nil
                    :ns "user"}
    :settings {:nrepl-port nil

--- a/src/main/clojure/com/github/clojure_repl/intellij/tests.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/tests.clj
@@ -1,6 +1,5 @@
 (ns com.github.clojure-repl.intellij.tests
   (:require
-   [com.github.clojure-repl.intellij.configuration.factory.base :as config.factory.base]
    [com.github.clojure-repl.intellij.db :as db]
    [com.github.clojure-repl.intellij.nrepl :as nrepl]
    [com.github.clojure-repl.intellij.parser :as parser]
@@ -34,9 +33,9 @@
                                 (fn []
                                   (ui.hint/show-error :message (format "No namespace '%s' found" ns) :editor editor))}))
            :on-out (fn [out]
-                     (ui.repl/append-result-text project (:console @config.factory.base/current-repl*) out))
+                     (ui.repl/append-result-text project (db/get-in project [:console :ui]) out))
            :on-err (fn [err]
-                     (ui.repl/append-result-text project (:console @config.factory.base/current-repl*) err))
+                     (ui.repl/append-result-text project (db/get-in project [:console :ui]) err))
            :on-failed (fn [result]
                         ;; TODO highlight errors on editor
                         (doseq [[key fns] (db/global-get-in [:on-test-failed-fns-by-key])]


### PR DESCRIPTION
This moves all other states to db since now we have it segregated by project making easier to manage and less error prone