### PR TITLE
Fix multiple responses from nrepl message

### DIFF
--- a/src/main/clojure/com/github/clojure_repl/intellij/action/eval_last_sexp.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/eval_last_sexp.clj
@@ -7,11 +7,11 @@
    [com.github.clojure-repl.intellij.nrepl :as nrepl]
    [com.github.clojure-repl.intellij.parser :as parser]
    [com.github.clojure-repl.intellij.ui.hint :as ui.hint]
-   [com.github.clojure-repl.intellij.ui.repl :as ui.repl]
    [com.github.ericdallo.clj4intellij.app-manager :as app-manager]
    [com.github.ericdallo.clj4intellij.tasks :as tasks]
    [com.github.ericdallo.clj4intellij.util :as util]
-   [rewrite-clj.zip :as z])
+   [rewrite-clj.zip :as z]
+   [clojure.string :as string])
   (:import
    [com.intellij.openapi.actionSystem CommonDataKeys]
    [com.intellij.openapi.actionSystem AnActionEvent]
@@ -34,14 +34,10 @@
                  zloc (parser/find-form-at-pos root-zloc (inc row) col)
                  code (z/string zloc)
                  ns (some-> (parser/find-namespace root-zloc) z/string)
-                 {:keys [value out err]} (nrepl/eval {:project project :code code :ns ns})]
-              ;; TODO how we can avoid coupling config.repl ns with this?
-              ;; maybe have a listener only for stdout?
-             (when out
-               (ui.repl/append-result-text project (db/get-in project [:console :ui]) out))
+                 {:keys [value err]} (nrepl/eval {:project project :code code :ns ns})]
              (app-manager/invoke-later!
               {:invoke-fn (fn []
                             (if err
                               (ui.hint/show-repl-error :message err :editor editor)
-                              (ui.hint/show-repl-info :message value :editor editor)))}))))
+                              (ui.hint/show-repl-info :message (string/join "\n" value) :editor editor)))}))))
         (ui.hint/show-error :message "No REPL connected" :editor editor)))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/load_file.clj
@@ -7,7 +7,6 @@
    [com.github.clojure-repl.intellij.db :as db]
    [com.github.clojure-repl.intellij.nrepl :as nrepl]
    [com.github.clojure-repl.intellij.ui.hint :as ui.hint]
-   [com.github.clojure-repl.intellij.ui.repl :as ui.repl]
    [com.github.ericdallo.clj4intellij.app-manager :as app-manager]
    [com.github.ericdallo.clj4intellij.tasks :as tasks])
   (:import
@@ -29,10 +28,8 @@
            (fn [_indicator]
              (let [path (.getCanonicalPath vf)
                    file (io/file path)
-                   {:keys [err]} (nrepl/load-file project file)]
+                   _ (nrepl/load-file project file)]
                (app-manager/invoke-later!
                 {:invoke-fn (fn []
-                              (when err
-                                (ui.repl/append-result-text project (db/get-in project [:console :ui]) err))
                               (ui.hint/show-repl-info :message (str "Loaded file " path) :editor editor))}))))
           (ui.hint/show-error :message "No REPL connected" :editor editor))))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/switch_ns.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/switch_ns.clj
@@ -3,6 +3,7 @@
    :name com.github.clojure_repl.intellij.action.SwitchNs
    :extends com.intellij.openapi.actionSystem.AnAction)
   (:require
+   [clojure.string :as string]
    [com.github.clojure-repl.intellij.db :as db]
    [com.github.clojure-repl.intellij.nrepl :as nrepl]
    [com.github.clojure-repl.intellij.parser :as parser]
@@ -27,5 +28,5 @@
               {:keys [value err]} (nrepl/eval {:project project :code (format "(in-ns '%s)" namespace) :ns namespace})]
           (if err
             (ui.hint/show-repl-error :message err :editor editor)
-            (ui.hint/show-repl-info :message value :editor editor)))
+            (ui.hint/show-repl-info :message (string/join "\n" value) :editor editor)))
         (ui.hint/show-error :message "No REPL connected" :editor editor)))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/local.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/local.clj
@@ -59,12 +59,12 @@
 
 (defn ^:private build-editor-view []
   (mig/mig-panel
-   :border (IdeBorderFactory/createTitledBorder "nREPL connection")
-   :items [[(seesaw/label "Project") ""]
-           [(seesaw/combobox :id    :project
-                             :model (->> (ProjectManager/getInstance)
-                                         .getOpenProjects
-                                         (map #(.getName ^Project %)))) "wrap"]]))
+    :border (IdeBorderFactory/createTitledBorder "nREPL connection")
+    :items [[(seesaw/label "Project") ""]
+            [(seesaw/combobox :id    :project
+                              :model (->> (ProjectManager/getInstance)
+                                          .getOpenProjects
+                                          (map #(.getName ^Project %)))) "wrap"]]))
 
 (set! *warn-on-reflection* false)
 (defn ^:private apply-editor-to [project ^RunConfigurationBase configuration-base]

--- a/src/main/clojure/com/github/clojure_repl/intellij/db.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/db.clj
@@ -43,6 +43,9 @@
 (defn assoc-in [^Project project fields value]
   (swap! db* clojure.core/assoc-in (concat [:projects (.getBasePath project)] fields) value))
 
+(defn update-in [^Project project fields fn]
+  (swap! db* clojure.core/update-in (concat [:projects (.getBasePath project)] fields) fn))
+
 (defn global-update-in [fields value]
   (swap! db* clojure.core/update-in fields value))
 

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
@@ -31,7 +31,7 @@
           result-text (str
                        (when err (str "\n" err))
                        (when out (str "\n" out))
-                       (when value (str "\n;; => " value)))
+                       (when value (str "\n;; => " (last value))))
           ns-text (str "\n" (db/get-in project [:current-nrepl :ns]) "> ")]
       (.append repl-content (str result-text ns-text)))
     (let [new-text (seesaw/text repl-content)]


### PR DESCRIPTION
Fixes #22 

This combine the multiple repsonses into one using a nrepl function to do that, now when running a test we can see multiple output:

![image](https://github.com/afucher/clojure-repl-intellij/assets/7820865/75ed7568-15b0-4e88-92e5-05dd2acff643)
