### PR TITLE
Fix noisy exceptions introduced on 1.0.1 when opening multiple projects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix noisy exceptions introduced on 1.0.1 when opening multiple projects.
+
 ## 1.0.1
  
 - Fix support for IntelliJ 2024.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 
 dependencies {
     implementation ("org.clojure:clojure:1.11.1")
-    implementation ("com.github.ericdallo:clj4intellij:0.5.1")
+    implementation ("com.github.ericdallo:clj4intellij:0.5.2")
     implementation ("com.rpl:proxy-plus:0.0.9")
     implementation ("seesaw:seesaw:1.5.0")
     implementation ("rewrite-clj:rewrite-clj:1.1.47")

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :mvn/repos {"intellij-1" {:url "https://cache-redirector.jetbrains.com/intellij-dependencies"}
              "intellij-2" {:url "https://www.jetbrains.com/intellij-repository/releases"}}
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        com.github.ericdallo/clj4intellij {:mvn/version "0.5.1"}
+        com.github.ericdallo/clj4intellij {:mvn/version "0.5.2"}
         com.rpl/proxy-plus {:mvn/version "0.0.9"}
         seesaw/seesaw {:mvn/version "1.5.0"}
         rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}}


### PR DESCRIPTION
We were registering the actions everytime a new project is opened, this fix these exceptions:

```
java.lang.Throwable: ID 'ClojureREPL.RunCursorTest' is already taken by action 'Run test at cursor (Run test at cursor)' (class com.intellij.openapi.actionSystem.impl.ChameleonAction) . Action 'Run test at cursor (Run test at cursor)' (class com.github.ericdallo.clj4intellij.action.proxy_plus2918) cannot use the same ID null
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:376)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImpl.reportActionIdCollision(ActionManagerImpl.kt:964)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImpl.registerAction(ActionManagerImpl.kt:906)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImpl.registerAction(ActionManagerImpl.kt:973)
	at com.github.ericdallo.clj4intellij.action$register_action_BANG_.invokeStatic(action.clj:28)
	at com.github.ericdallo.clj4intellij.action$register_action_BANG_.doInvoke(action.clj:18)
	at clojure.lang.RestFn.invoke(RestFn.java:1096)
	at com.github.clojure_repl.intellij.extension.register_actions_startup$_runActivity.invokeStatic(register_actions_startup.clj:17)
	at com.github.clojure_repl.intellij.extension.register_actions_startup$_runActivity.invoke(register_actions_startup.clj:16)
	at com.github.clojure_repl.intellij.extension.RegisterActionsStartup.runActivity(Unknown Source)
	at com.intellij.ide.startup.impl.StartupManagerImpl.runOldActivity(StartupManagerImpl.kt:328)
	at com.intellij.ide.startup.impl.StartupManagerImpl.access$runOldActivity(StartupManagerImpl.kt:69)
	at com.intellij.ide.startup.impl.StartupManagerImpl$runPostStartupActivities$5$1.invoke(StartupManagerImpl.kt:271)
	at com.intellij.ide.startup.impl.StartupManagerImpl$runPostStartupActivities$5$1.invoke(StartupManagerImpl.kt:270)
	at com.intellij.openapi.progress.CoroutinesKt.blockingContextInner(coroutines.kt:321)
	at com.intellij.openapi.progress.CoroutinesKt.access$blockingContextInner(coroutines.kt:1)
	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invokeSuspend(coroutines.kt:198)
	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invoke(coroutines.kt)
	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invoke(coroutines.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:78)
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:264)
	at com.intellij.openapi.progress.CoroutinesKt.blockingContext(coroutines.kt:197)
	at com.intellij.ide.startup.impl.StartupManagerImpl.runPostStartupActivities(StartupManagerImpl.kt:270)
	at com.intellij.ide.startup.impl.StartupManagerImpl.access$runPostStartupActivities(StartupManagerImpl.kt:69)
	at com.intellij.ide.startup.impl.StartupManagerImpl$runPostStartupActivities$3$2.invokeSuspend(StartupManagerImpl.kt:192)
	at com.intellij.ide.startup.impl.StartupManagerImpl$runPostStartupActivities$3$2.invoke(StartupManagerImpl.kt)
	at com.intellij.ide.startup.impl.StartupManagerImpl$runPostStartupActivities$3$2.invoke(StartupManagerImpl.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:78)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:167)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	at com.intellij.ide.startup.impl.StartupManagerImpl$runPostStartupActivities$3.invokeSuspend(StartupManagerImpl.kt:191)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.UndispatchedCoroutine.afterResume(CoroutineContext.kt:270)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:102)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684)
```