### PR TITLE
regression: Fix load file to handle errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix Load file action not showing the error in case of eval error.
+
 ## 1.0.2
 
 - Fix noisy exceptions introduced on 1.0.1 when opening multiple projects.

--- a/src/main/clojure/com/github/clojure_repl/intellij/extension/register_actions_startup.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/extension/register_actions_startup.clj
@@ -19,31 +19,31 @@
                            :description "Run test at cursor"
                            :icon Icons/CLOJURE_REPL
                            :keyboard-shortcut {:first "shift alt T" :second "shift alt T" :replace-all true}
-                           :on-performed a.test/run-cursor-test-action)
+                           :on-performed #'a.test/run-cursor-test-action)
   (action/register-action! :id "ClojureREPL.RunNsTests"
                            :title "Run namespace tests"
                            :description "Run all namespaces tests"
                            :icon Icons/CLOJURE_REPL
                            :keyboard-shortcut {:first "shift alt T" :second "shift alt N" :replace-all true}
-                           :on-performed a.test/run-ns-tests-action)
+                           :on-performed #'a.test/run-ns-tests-action)
   (action/register-action! :id "ClojureREPL.LoadFile"
                            :title "Load file to REPL"
                            :description "Load file to REPL"
                            :icon Icons/CLOJURE_REPL
                            :keyboard-shortcut {:first "shift alt L" :replace-all true}
-                           :on-performed a.eval/load-file-action)
+                           :on-performed #'a.eval/load-file-action)
   (action/register-action! :id "ClojureREPL.EvalLastSexp"
                            :title "Eval last sexp"
                            :description "Eval the expression preceding cursor"
                            :icon Icons/CLOJURE_REPL
                            :keyboard-shortcut {:first "shift alt E" :replace-all true}
-                           :on-performed a.eval/eval-last-sexpr-action)
+                           :on-performed #'a.eval/eval-last-sexpr-action)
   (action/register-action! :id "ClojureREPL.SwitchNs"
                            :title "Switch REPL namespace"
                            :description "Switch REPL namespace to current opened file namespace"
                            :icon Icons/CLOJURE_REPL
                            :keyboard-shortcut {:first "shift alt N" :replace-all true}
-                           :on-performed a.eval/switch-ns-action)
+                           :on-performed #'a.eval/switch-ns-action)
 
   (action/register-group! :id "ClojureREPL.ReplActions"
                           :popup true

--- a/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
@@ -4,6 +4,7 @@
    [com.github.clojure-repl.intellij.db :as db]
    [nrepl.core :as nrepl.core])
   (:import
+   [com.intellij.openapi.editor Editor]
    [com.intellij.openapi.project Project]
    [nrepl.transport FnTransport]))
 
@@ -32,15 +33,15 @@
 (defn clone-session [^Project project]
   (db/assoc-in project [:current-nrepl :session-id] (:new-session (send-message project {:op "clone"}))))
 
-(defn load-file [project ^java.io.File file]
-  (let [result (send-message project {:op "load-file"
-                                      :session (db/get-in project [:current-nrepl :session-id])
-                                      :file (slurp file)
-                                      :file-path (.getCanonicalPath file)
-                                      :file-name (.getName file)})]
-    (doseq [fn (db/get-in project [:on-repl-file-loaded-fns])]
-      (fn file))
-    result))
+(defn load-file [project ^Editor editor]
+  (let [response (send-message project {:op "load-file"
+                                        :session (db/get-in project [:current-nrepl :session-id])
+                                        :file (.getText (.getDocument editor))
+                                        :file-path  (some-> (.getVirtualFile editor) .getPath)
+                                        :file-name (some-> (.getVirtualFile editor) .getName)})]
+    (doseq [fn (db/get-in project [:on-repl-evaluated-fns])]
+      (fn project response))
+    response))
 
 (defn describe [^Project project]
   (send-message project {:op "describe"}))


### PR DESCRIPTION
- When a namespace has a eval error we were not showing the error + saying the file was loaded which is wrong
- not require to save the file to load it, use current changes in buffer