### PR TITLE
Fix print failing test

### DIFF
--- a/src/main/clojure/com/github/clojure_repl/intellij/config.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/config.clj
@@ -1,0 +1,25 @@
+(ns com.github.clojure-repl.intellij.config
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+(defonce ^:private cache* (atom {}))
+
+(defn ^:private memoize-if-not-nil [f]
+  (fn []
+    (if-let [cached-result (get @cache* f)]
+      cached-result
+      (if-let [result (f)]
+        (do (swap! cache* assoc f result)
+            result)
+        nil))))
+
+(defn ^:private config* []
+  (try
+    (edn/read-string (slurp (io/resource "META-INF/clojure-repl-intellij.edn")))
+    (catch Exception _ nil)))
+
+(def ^:private config (memoize-if-not-nil config*))
+
+(defn nrepl-debug? []
+  (-> (config) :nrepl-debug))

--- a/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
@@ -1,7 +1,9 @@
 (ns com.github.clojure-repl.intellij.nrepl
   (:refer-clojure :exclude [eval load-file])
   (:require
+   [com.github.clojure-repl.intellij.config :as config]
    [com.github.clojure-repl.intellij.db :as db]
+   [com.github.ericdallo.clj4intellij.logger :as logger]
    [nrepl.core :as nrepl.core])
   (:import
    [com.intellij.openapi.editor Editor]
@@ -12,15 +14,20 @@
 (set! *warn-on-reflection* true)
 
 (defn ^:private send-message [project message]
-  (with-open [conn ^FnTransport (nrepl.core/connect
-                                 :host (db/get-in project [:current-nrepl :nrepl-host])
-                                 :port (db/get-in project [:current-nrepl :nrepl-port]))]
-    ;; TODO Improve this timeout, what will happen for tests/evals
-    ;; taking more than this timeout? should we really fail?
-    (-> (nrepl.core/client conn 60000)
-        (nrepl.core/message message)
-        doall
-        nrepl.core/combine-responses)))
+  (when (config/nrepl-debug?)
+    (logger/info "Requesting:" message))
+  (let [response (with-open [conn ^FnTransport (nrepl.core/connect
+                                                :host (db/get-in project [:current-nrepl :nrepl-host])
+                                                :port (db/get-in project [:current-nrepl :nrepl-port]))]
+                   ;; TODO Improve this timeout, what will happen for tests/evals
+                   ;; taking more than this timeout? should we really fail?
+                   (-> (nrepl.core/client conn 60000)
+                       (nrepl.core/message message)
+                       doall
+                       nrepl.core/combine-responses))]
+    (when (config/nrepl-debug?)
+      (logger/info "Responded:" response))
+    response))
 
 (defn eval [& {:keys [^Project project ns code]
                :or {ns (or (db/get-in project [:current-nrepl :ns]) "user")}}]
@@ -48,10 +55,16 @@
   (send-message project {:op "describe"}))
 
 (defn sym-info [^Project project ns sym]
-  (send-message project {:op "info" :ns ns :sym sym}))
+  (send-message project {:op "info" :ns ns :sym sym :session (db/get-in project [:current-nrepl :session-id])}))
 
 (defn run-tests [^Project project {:keys [ns tests on-ns-not-found on-out on-err on-succeeded on-failed]}]
-  (let [{:keys [summary results status out err] :as response} (send-message project {:op "test" :ns ns :tests (when (seq tests) tests)})]
+  (let [{:keys [summary results status out err] :as response}
+        (send-message project {:op "test"
+                               :load? (str (boolean ns))
+                               :session (db/get-in project [:current-nrepl :session-id])
+                               :ns ns
+                               :tests (when (seq tests) tests)
+                               :fail-fast  "true"})]
     (when (some #(= % "namespace-not-found") status)
       (on-ns-not-found ns))
     (when out (on-out out))

--- a/src/main/dev-resources/META-INF/clojure-repl-intellij.edn
+++ b/src/main/dev-resources/META-INF/clojure-repl-intellij.edn
@@ -1,0 +1,1 @@
+{:nrepl-debug true}


### PR DESCRIPTION
Fixes #62 

- fix test op not using current session, failing tests when need to print to out.
- log nrepl messages during debug