### PR TITLE
Refactor nrepl communication to handle Transport manually

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,9 @@ repositories {
 
 dependencies {
     implementation ("org.clojure:clojure:1.11.1")
+    implementation ("org.clojure:core.async:1.5.648") {
+        because("issue https://clojure.atlassian.net/browse/ASYNC-248")
+    }
     implementation ("com.github.ericdallo:clj4intellij:0.5.2")
     implementation ("com.rpl:proxy-plus:0.0.9")
     implementation ("seesaw:seesaw:1.5.0")

--- a/deps.edn
+++ b/deps.edn
@@ -2,6 +2,7 @@
  :mvn/repos {"intellij-1" {:url "https://cache-redirector.jetbrains.com/intellij-dependencies"}
              "intellij-2" {:url "https://www.jetbrains.com/intellij-repository/releases"}}
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        org.clojure/core.async {:mvn/version "1.5.648"}
         com.github.ericdallo/clj4intellij {:mvn/version "0.5.2"}
         com.rpl/proxy-plus {:mvn/version "0.0.9"}
         seesaw/seesaw {:mvn/version "1.5.0"}

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
@@ -67,6 +67,11 @@
   (db/update-in! project [:on-repl-evaluated-fns] (fn [fns] (remove #(= on-repl-evaluated %) fns))))
 
 (defn repl-started [project extra-initial-text]
+  (nrepl/start-client!
+   :project project
+   :on-receive-async-message (fn [msg]
+                               (when (:out msg)
+                                 (ui.repl/append-result-text project (db/get-in project [:console :ui]) (:out msg)))))
   (nrepl/clone-session project)
   (nrepl/eval {:project project :code "*ns*"})
   (let [description (nrepl/describe project)]

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/local.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/local.clj
@@ -16,9 +16,10 @@
     ConfigurationType
     GeneralCommandLine
     RunConfigurationBase]
-   [com.intellij.execution.process ProcessEvent ProcessHandlerFactory ProcessListener]
+   [com.intellij.execution.process ColoredProcessHandler ProcessEvent ProcessListener]
    [com.intellij.execution.runners ExecutionEnvironment]
    [com.intellij.openapi.project Project]
+   [com.intellij.util.io BaseOutputReader$Options]
    [java.nio.charset Charset]))
 
 (set! *warn-on-reflection* true)
@@ -39,8 +40,9 @@
         command-line  (doto (GeneralCommandLine. ^java.util.List command)
                         (.setCharset (Charset/forName "UTF-8"))
                         (.setWorkDirectory (.getBasePath project)))
-        handler (.createColoredProcessHandler (ProcessHandlerFactory/getInstance)
-                                              command-line)]
+        handler (proxy [ColoredProcessHandler] [command-line]
+                  (readerOptions []
+                    (BaseOutputReader$Options/forMostlySilentProcess)))]
     (db/assoc-in! project [:console :process-handler] handler)
     (.addProcessListener handler
                          (proxy+ [] ProcessListener

--- a/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
@@ -1,37 +1,84 @@
 (ns com.github.clojure-repl.intellij.nrepl
   (:refer-clojure :exclude [eval load-file])
   (:require
+   [clojure.core.async :as async]
+   [clojure.string :as string]
    [com.github.clojure-repl.intellij.config :as config]
    [com.github.clojure-repl.intellij.db :as db]
    [com.github.ericdallo.clj4intellij.logger :as logger]
-   [nrepl.core :as nrepl.core])
+   [nrepl.core :as nrepl.core]
+   [nrepl.transport :as transport])
   (:import
    [com.intellij.openapi.editor Editor]
    [com.intellij.openapi.project Project]
-   [com.intellij.openapi.vfs VirtualFile]
-   [nrepl.transport FnTransport]))
+   [com.intellij.openapi.vfs VirtualFile]))
 
 (set! *warn-on-reflection* true)
 
-(defn ^:private send-message [project message]
-  (when (config/nrepl-debug?)
-    (logger/info "Requesting:" message))
-  (let [response (with-open [conn ^FnTransport (nrepl.core/connect
-                                                :host (db/get-in project [:current-nrepl :nrepl-host])
-                                                :port (db/get-in project [:current-nrepl :nrepl-port]))]
-                   ;; TODO Improve this timeout, what will happen for tests/evals
-                   ;; taking more than this timeout? should we really fail?
-                   (-> (nrepl.core/client conn 60000)
-                       (nrepl.core/message message)
-                       doall
-                       nrepl.core/combine-responses))]
+(defprotocol REPLClient
+  (start! [this])
+  (log! [this level arg1] [this level arg1 arg2])
+  (send-message! [this msg]))
+
+(defrecord ^:private NREPLClient [host port join sent-messages* received-messages* conn* on-receive-async-message]
+  REPLClient
+  (start! [this]
+    (log! this :info "connecting...")
+    (reset! conn* (nrepl.core/connect :host host :port port))
+    (async/thread
+      (loop []
+        (if-let [{:keys [id status] :as resp} (transport/recv @conn*)]
+          (do
+            (when-not (:changed-namespaces resp)
+              (log! this :info "received message:" resp)
+              (if-let [sent-request (get @sent-messages* id)]
+                (do
+                  (swap! received-messages* update id conj resp)
+                  (when (and status (contains? (set status) "done"))
+                    (let [responses (get @received-messages* id)]
+                      (swap! sent-messages* dissoc id)
+                      (swap! received-messages* dissoc id)
+                      (deliver sent-request (nrepl.core/combine-responses responses)))))
+                (on-receive-async-message resp)))
+            (recur))
+          (deliver join :done))))
+    (log! this :info "connected")
+    join)
+  (send-message! [this msg]
+    (let [id (str (random-uuid))
+          p (promise)
+          msg (assoc msg :id id)]
+      (log! this :info "sending message:" msg)
+      (swap! sent-messages* assoc id p)
+      (transport/send @conn* msg)
+      p))
+  (log! [this msg params]
+    (log! this :info msg params))
+  (log! [_this _color msg params]
     (when (config/nrepl-debug?)
-      (logger/info "Responded:" response))
-    response))
+      (logger/info "[NREPLClient] " (string/join " " [msg params])))))
+
+(defn ^:private nrepl-client [^Project project on-receive-async-message]
+  (map->NREPLClient {:host (db/get-in project [:current-nrepl :nrepl-host])
+                     :port (db/get-in project [:current-nrepl :nrepl-port])
+                     :join (promise)
+                     :on-receive-async-message on-receive-async-message
+                     :conn* (atom nil)
+                     :sent-messages* (atom {})
+                     :received-messages* (atom {})}))
+
+(defn start-client! [& {:keys [project on-receive-async-message]}]
+  (let [client (nrepl-client project on-receive-async-message)]
+    (db/assoc-in! project [:current-nrepl :client] client)
+    (start! client)))
+
+(defn ^:private send-msg [project message]
+  (let [client (db/get-in project [:current-nrepl :client])]
+    (send-message! client message)))
 
 (defn eval [& {:keys [^Project project ns code]
                :or {ns (or (db/get-in project [:current-nrepl :ns]) "user")}}]
-  (let [{:keys [ns] :as response} (send-message project {:op "eval" :code code :ns ns :session (db/get-in project [:current-nrepl :session-id])})]
+  (let [{:keys [ns] :as response} @(send-msg project {:op "eval" :code code :ns ns :session (db/get-in project [:current-nrepl :session-id])})]
     (when ns
       (db/assoc-in! project [:current-nrepl :ns] ns))
     (doseq [fn (db/get-in project [:on-repl-evaluated-fns])]
@@ -39,35 +86,35 @@
     response))
 
 (defn clone-session [^Project project]
-  (db/assoc-in! project [:current-nrepl :session-id] (:new-session (send-message project {:op "clone"}))))
+  (db/assoc-in! project [:current-nrepl :session-id] (:new-session @(send-msg project {:op "clone"}))))
 
 (defn load-file [project ^Editor editor ^VirtualFile virtual-file]
-  (let [response (send-message project {:op "load-file"
-                                        :session (db/get-in project [:current-nrepl :session-id])
-                                        :file (.getText (.getDocument editor))
-                                        :file-path  (some-> virtual-file .getPath)
-                                        :file-name (some-> virtual-file .getName)})]
+  (let [response @(send-msg project {:op "load-file"
+                                     :session (db/get-in project [:current-nrepl :session-id])
+                                     :file (.getText (.getDocument editor))
+                                     :file-path  (some-> virtual-file .getPath)
+                                     :file-name (some-> virtual-file .getName)})]
     (doseq [fn (db/get-in project [:on-repl-evaluated-fns])]
       (fn project response))
     response))
 
 (defn describe [^Project project]
-  (send-message project {:op "describe"}))
+  @(send-msg project {:op "describe"}))
 
 (defn out-subscribe [^Project project]
-  (send-message project {:op "out-subscribe" :session (db/get-in project [:current-nrepl :session-id])}))
+  @(send-msg project {:op "out-subscribe" :session (db/get-in project [:current-nrepl :session-id])}))
 
 (defn sym-info [^Project project ns sym]
-  (send-message project {:op "info" :ns ns :sym sym :session (db/get-in project [:current-nrepl :session-id])}))
+  @(send-msg project {:op "info" :ns ns :sym sym :session (db/get-in project [:current-nrepl :session-id])}))
 
 (defn run-tests [^Project project {:keys [ns tests on-ns-not-found on-out on-err on-succeeded on-failed]}]
   (let [{:keys [summary results status out err] :as response}
-        (send-message project {:op "test"
-                               :load? (str (boolean ns))
-                               :session (db/get-in project [:current-nrepl :session-id])
-                               :ns ns
-                               :tests (when (seq tests) tests)
-                               :fail-fast  "true"})]
+        @(send-msg project {:op "test"
+                            :load? (str (boolean ns))
+                            :session (db/get-in project [:current-nrepl :session-id])
+                            :ns ns
+                            :tests (when (seq tests) tests)
+                            :fail-fast  "true"})]
     (when (some #(= % "namespace-not-found") status)
       (on-ns-not-found ns))
     (when out (on-out out))


### PR DESCRIPTION
- Fixes #65
- Fix a exception that happens after some seconds of repl running:
```
If it's a long-running mostly idle daemon process, consider overriding OSProcessHandler#readerOptions with 'BaseOutputReader.Options.forMostlySilentProcess()' to reduce CPU usage.
Command line: lein update-in :dependencies conj "[nrepl/nrepl \"1.0.0\"]" -- update-in :plugins conj "[cider/cider-nrepl \"0.45.0\"]" -- repl :headless :host localhost
java.lang.Throwable: Process creation:
        at com.intellij.execution.process.BaseOSProcessHandler.<init>
```


This PR refactors how we communicate with NREPL, the major problem is that nrepl is a server so it can send messages at any time through the socket, and we were ignoring those messages, only caring by the ones we sent sync.


Code snippets to test:

```clojure

(deftest a-test
  (println "foo")
  (is (= {:a 2 :b 2}
         (sample.core/|fob))))

(future (Thread/sleep 1000) (println "foo"))

```