### PR TITLE
Add new action to eval defun at cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fixes Prints to stdout/stderr do not show on REPL when happens async (tests, async threads) #65
 - Fix a exception that happens after some seconds of repl running
 
+- Add new eval defun action.
+
 ## 1.0.4
 
 - Fix print failing tests. #62

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ configurations.
 - Connect to an existing nREPL process
 - Load file to REPL (`alt + shift + l` / `opt + shift + l`)
 - Eval code at point (`alt + shift + e` / `opt + shift + e`)
+- Eval defun at point (`alt + shift + d` / `opt + shift + d`)
 - Switch to file namespace (`alt + shift + n` / `opt + shift + n`)
 - Run ns tests  (`alt + shift + t` `alt + shift + n` / `opt + shift + t` `opt + shift + n`)
 - Run test at cursor (`alt + shift + t` `alt + shift + t` / `opt + shift + t` `opt + shift + t`)

--- a/doc/shortcuts.md
+++ b/doc/shortcuts.md
@@ -2,10 +2,11 @@
 
 ## Actions
 
-| Shortcut                            | Description        |
-|-------------------------------------|--------------------|
-| `alt/opt+shift+e`                   | Evaluate last sexp |
-| `alt/opt+shift+l`                   | Load file          |
-| `alt/opt+shift+n`                   | Switch namespace   |
-| `alt/opt+shift+t` `alt/opt+shift+t` | Run test at cursor |
-| `alt/opt+shift+t` `alt/opt+shift+n` | Run ns tests       |
+| Shortcut                            | Description              |
+|-------------------------------------|--------------------------|
+| `alt/opt+shift+e`                   | Evaluate last sexp       |
+| `alt/opt+shift+d`                   | Evaluate defun at cursor |
+| `alt/opt+shift+l`                   | Load file                |
+| `alt/opt+shift+n`                   | Switch namespace         |
+| `alt/opt+shift+t` `alt/opt+shift+t` | Run test at cursor       |
+| `alt/opt+shift+t` `alt/opt+shift+n` | Run ns tests             |

--- a/src/main/clojure/com/github/clojure_repl/intellij/extension/register_actions_startup.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/extension/register_actions_startup.clj
@@ -38,6 +38,12 @@
                            :icon Icons/CLOJURE_REPL
                            :keyboard-shortcut {:first "shift alt E" :replace-all true}
                            :on-performed #'a.eval/eval-last-sexpr-action)
+  (action/register-action! :id "ClojureREPL.EvalDefun"
+                           :title "Eval defun at cursor"
+                           :description "Evaluate the current toplevel form"
+                           :icon Icons/CLOJURE_REPL
+                           :keyboard-shortcut {:first "shift alt D" :replace-all true}
+                           :on-performed #'a.eval/eval-defun-action)
   (action/register-action! :id "ClojureREPL.SwitchNs"
                            :title "Switch REPL namespace"
                            :description "Switch REPL namespace to current opened file namespace"
@@ -55,5 +61,6 @@
                                      {:type :reference :ref "ClojureREPL.RunNsTests"}
                                      {:type :reference :ref "ClojureREPL.LoadFile"}
                                      {:type :reference :ref "ClojureREPL.EvalLastSexp"}
+                                     {:type :reference :ref "ClojureREPL.ClojureREPL.EvalDefun"}
                                      {:type :reference :ref "ClojureREPL.SwitchNs"}
                                      {:type :separator}]))


### PR DESCRIPTION
This adds a new action to eval the current top level form (defun) at cursor, used a lot in cider and calva

![image](https://github.com/afucher/clojure-repl-intellij/assets/7820865/79ee6e72-5e7e-4e67-83fb-df5b38d8bee5)
