### PR TITLE
Add support to entry history navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [Unreleased]
 
+- Add entry history navigation with `ctrl + PG_UP` and `ctrl + PG_DOWN`
+
 ## 1.2.0
 
 - Fix remote run configuration wrong state after open a previously saved configuration.
+- Add support alias for Clojure and Lein project types
+- Add support choosing project type for local repl instead of only guess, now we guess when creating the run configuration but let user choose a different one.
 
 ## 1.1.2
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ configurations.
 - Switch to file namespace (`alt + shift + n` / `opt + shift + n`)
 - Run ns tests  (`alt + shift + t` `alt + shift + n` / `opt + shift + t` `opt + shift + n`)
 - Run test at cursor (`alt + shift + t` `alt + shift + t` / `opt + shift + t` `opt + shift + t`)
+- Entry history navigation in REPL (`ctrl + PAGE_UP` or `ctrl + PAGE_DOWN`)
 
 ### Soon
 

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
@@ -79,5 +79,7 @@
       (nrepl/out-subscribe project))
     (db/assoc-in! project [:current-nrepl :ops] (:ops description))
     (db/assoc-in! project [:current-nrepl :versions] (:versions description))
+    (db/assoc-in! project [:current-nrepl :entry-history] [])
+    (db/assoc-in! project [:current-nrepl :entry-index] -1)
     (ui.repl/set-initial-text project (db/get-in project [:console :ui]) (str (initial-repl-text project) extra-initial-text))
     (db/update-in! project [:on-repl-evaluated-fns] #(conj % on-repl-evaluated))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/db.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/db.clj
@@ -19,7 +19,7 @@
                    :nrepl-port nil
                    :nrepl-host nil
                    :entry-history []
-                   :entry-index 0}
+                   :entry-index -1}
    :on-repl-file-loaded-fns []
    :on-repl-evaluated-fns []
    :ops {}})

--- a/src/main/clojure/com/github/clojure_repl/intellij/db.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/db.clj
@@ -17,7 +17,9 @@
    :current-nrepl {:session-id nil
                    :ns "user"
                    :nrepl-port nil
-                   :nrepl-host nil}
+                   :nrepl-host nil
+                   :entry-history []
+                   :entry-index 0}
    :on-repl-file-loaded-fns []
    :on-repl-evaluated-fns []
    :ops {}})

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
@@ -41,24 +41,23 @@
       (db/assoc-in! project [:console :state :last-output] new-text))))
 
 (defn ^:private on-repl-history-entry [project ^KeyEvent key-event]
-  (.consume key-event)
   (let [repl-content ^JTextArea (.getComponent key-event)
         last-output (db/get-in project [:console :state :last-output])
-        up? (= KeyEvent/VK_UP (.getKeyCode key-event))
-        down? (= KeyEvent/VK_DOWN (.getKeyCode key-event))
+        page-up? (= KeyEvent/VK_PAGE_UP (.getKeyCode key-event))
+        page-down? (= KeyEvent/VK_PAGE_DOWN (.getKeyCode key-event))
         current-index (db/get-in project [:current-nrepl :entry-index])
         entries (db/get-in project [:current-nrepl :entry-history])]
-    (when up?
-      (when (<= current-index (count entries))
-        (db/update-in! project [:current-nrepl :entry-index] inc)
-        (let [entry (get entries (inc current-index))] 
-          (.setText repl-content (str last-output entry)))))
-    (when down?
-      (when (pos? current-index)
-        (db/update-in! project [:current-nrepl :entry-index] dec)
-        (let [entry (get entries (dec current-index))]
-          (.setText repl-content (str last-output entry)))))))
-  
+    (when (pos? (count entries))
+      (when page-up?
+        (when (< current-index (count entries))
+          (db/update-in! project [:current-nrepl :entry-index] inc)
+          (let [entry (get entries (inc current-index))]
+            (.setText repl-content (str last-output entry)))))
+      (when page-down?
+        (when-not (neg? current-index)
+          (db/update-in! project [:current-nrepl :entry-index] dec)
+          (let [entry (get entries (dec current-index))]
+            (.setText repl-content (str last-output entry))))))))
 
 (defn ^:private on-repl-new-line [^KeyEvent key-event]
   (.consume key-event)
@@ -92,13 +91,12 @@
                                       (if (identical? :enabled (db/get-in project [:console :state :status]))
                                         (let [ctrl? (not= 0 (bit-and (.getModifiers event) InputEvent/CTRL_MASK))
                                               shift? (not= 0 (bit-and (.getModifiers event) InputEvent/SHIFT_MASK))
-                                              alt? (not= 0 (bit-and (.getModifiers event) InputEvent/ALT_MASK))
                                               enter? (= KeyEvent/VK_ENTER (.getKeyCode event))
                                               l? (= KeyEvent/VK_L (.getKeyCode event))
-                                              up? (= KeyEvent/VK_UP (.getKeyCode event))
-                                              down? (= KeyEvent/VK_DOWN (.getKeyCode event))]
+                                              page-up? (= KeyEvent/VK_PAGE_UP (.getKeyCode event))
+                                              page-down? (= KeyEvent/VK_PAGE_DOWN (.getKeyCode event))]
                                           (cond
-                                            (or (and alt? up?) (and alt? down?))
+                                            (or (and ctrl? page-up?) (and ctrl? page-down?))
                                             (on-repl-history-entry project event)
 
                                             (and shift? enter?)

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
@@ -48,16 +48,16 @@
         current-index (db/get-in project [:current-nrepl :entry-index])
         entries (db/get-in project [:current-nrepl :entry-history])]
     (when (pos? (count entries))
-      (when page-up?
-        (when (< current-index (count entries))
+      (when (and page-up?
+                 (< current-index (count entries)))
           (db/update-in! project [:current-nrepl :entry-index] inc)
           (let [entry (get entries (inc current-index))]
-            (.setText repl-content (str last-output entry)))))
-      (when page-down?
-        (when-not (neg? current-index)
+            (seesaw/config! repl-content :text (str last-output entry))))
+      (when (and page-down?
+                 (not (neg? current-index)))
           (db/update-in! project [:current-nrepl :entry-index] dec)
           (let [entry (get entries (dec current-index))]
-            (.setText repl-content (str last-output entry))))))))
+            (seesaw/config! repl-content :text (str last-output entry)))))))
 
 (defn ^:private on-repl-new-line [^KeyEvent key-event]
   (.consume key-event)


### PR DESCRIPTION
Add support to entry history navigation. 
Uses `ctrl+PG_UP` and `ctrl+PG_DOWN` to navigate.

https://github.com/afucher/clojure-repl-intellij/assets/3756185/92debcd5-f317-4c60-8bdb-290af4540c0f

Closes #66 