### PR TITLE
Sets the color of the repl to IntelliJ's background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## [Unreleased]
-## 1.4.2
 - add dynamic background color to REPL
 - add instructions to download babashka
 ## 1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+## 1.4.2
 - add dynamic background color to REPL
 - add instructions to download babashka
 ## 1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [Unreleased]
-
+- add dynamic background color to REPL
+- add instructions to download babashka
 ## 1.4.1
 
 - Fix REPL input parse of functions with `>` char. #79

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Contributions are very welcome, check the [issues page](https://github.com/afuch
 
 
 ## Developing
+install babashka from https://github.com/babashka/babashka#installation
 
 `bb run-ide` to spawn a new IntelliJ session with the plugin.
 

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/color.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/color.clj
@@ -10,7 +10,7 @@
 (def normal-foreground (UIUtil/getToolTipForeground))
 (def fail-foreground JBColor/RED)
 (def error-foreground JBColor/RED)
-
+(def editor-background-color (JBColor/background))
 (def low-light-foreground JBColor/GRAY)
 
 (defn remove-ansi-color ^String [text]

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
@@ -13,7 +13,7 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private color-repl-primary "#1d252c")
+(def ^:private color-repl-primary ui.color/editor-background-color)
 
 (def ^:private code-to-eval-regexp
   #"(?mx)                    # match multiline and allow comments


### PR DESCRIPTION
Picture of the REPL now inheriting the right color 
<img width="1392" alt="Screenshot 2024-07-10 at 10 43 11 AM" src="https://github.com/afucher/clojure-repl-intellij/assets/95664513/87668395-98bd-4213-a8e5-e1af64994586">
