### PR TITLE
Fix - in RELP actions shouldn't consider namespace metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix ignore namespace metadata in REPL 
+
 ## 1.4.1
 
 - Fix REPL input parse of functions with `>` char. #79

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/eval.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/eval.clj
@@ -56,7 +56,7 @@
                root-zloc (z/of-string text)
                zloc (parser/find-form-at-pos root-zloc (inc row) col)
                code (z/string zloc)
-               ns (some-> (parser/find-namespace root-zloc) z/string)]
+               ns (some-> (parser/find-namespace root-zloc) z/string parser/remove-metadata)]
            (nrepl/eval {:project (.getProject editor) :code code :ns ns})))
        (fn [response]
          (string/join "\n" (:value response)))))))
@@ -72,7 +72,7 @@
            zloc (-> (parser/find-form-at-pos root-zloc (inc row) col)
                     parser/to-top)
            code (z/string zloc)
-           ns (some-> (parser/find-namespace root-zloc) z/string)]
+           ns (some-> (parser/find-namespace root-zloc) z/string parser/remove-metadata)]
        (nrepl/eval {:project (.getProject editor) :code code :ns ns})))
    (fn [response]
      (string/join "\n" (:value response)))))
@@ -90,7 +90,7 @@
      (let [text (.getText (.getDocument editor))
            root-zloc (z/of-string text)
            zloc (parser/find-namespace root-zloc)
-           namespace (z/string zloc)]
+           namespace (parser/remove-metadata (z/string zloc))]
        (nrepl/eval {:project (.getProject editor) :code (format "(in-ns '%s)" namespace) :ns namespace})))
    (fn [response]
      (string/join "\n" (:value response)))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/parser.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/parser.clj
@@ -1,5 +1,6 @@
 (ns com.github.clojure-repl.intellij.parser
   (:require
+   [clojure.string :as string]
    [rewrite-clj.zip :as z]))
 
 (defn find-by-heritability
@@ -98,3 +99,7 @@
   (-> (to-root zloc)
       (z/find-value z/next 'ns)
       z/next))
+
+(defn remove-metadata [zloc]
+  (-> (string/replace zloc #"(\^\S+\s+)+" "")
+      (string/trim)))

--- a/src/main/clojure/com/github/clojure_repl/intellij/tests.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/tests.clj
@@ -65,7 +65,7 @@
   (let [text (.getText (.getDocument editor))
         root-zloc (z/of-string text)
         [row col] (util/editor->cursor-position editor)
-        ns (-> (parser/find-namespace root-zloc) z/string)]
+        ns (-> (parser/find-namespace root-zloc) z/string parser/remove-metadata)]
     (if-let [test (some-> (parser/find-var-at-pos root-zloc (inc row) col) z/string)]
       (run editor ns [test])
       (ui.hint/show-error :message "No test var found, did you eval the var?" :editor editor))))
@@ -74,5 +74,5 @@
   (let [text (.getText (.getDocument editor))
         root-zloc (z/of-string text)
         zloc (parser/find-namespace root-zloc)
-        ns (z/string zloc)]
+        ns (parser/remove-metadata (z/string zloc))]
     (run editor ns nil)))


### PR DESCRIPTION
Problem:
* It is considering the metadata as the namespace name, so when trying to change the namespace in RELP, an error occurs.

**Without metadata:**
![image](https://github.com/user-attachments/assets/3a591a7f-72ad-4d82-b068-5fbf1fe42628)

**With metadata:**
![image](https://github.com/user-attachments/assets/a27a5bc1-1112-4b3f-8077-2e2276e64ded)

**After fix:**
![image](https://github.com/user-attachments/assets/3ffadf98-c73b-40f3-a068-966b43b97466)
