### PR TITLE
Add a link to the plugin to the Getting started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Checkout all available [features](https://github.com/afucher/clojure-repl-intell
 
 ---
 ## Getting Started
-After installing the plugin in IntelliJ, you can add a REPL to your Run
+After installing [the plugin](https://plugins.jetbrains.com/plugin/23073-clojure-repl) in IntelliJ, you can add a REPL to your Run
 configurations.
 
 ### Local: Start a nREPL server from IntelliJ


### PR DESCRIPTION
It took me a minute to find the link. I believe that adding the link here will remove a tiny bit of friction for some users