### PR TITLE
segregate test fns by project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix error when running tests after open multiple projects
+
 ## 1.6.0
 
 - Fix shortcuts not being added after 1.5.1.

--- a/src/main/clojure/com/github/clojure_repl/intellij/db.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/db.clj
@@ -23,11 +23,11 @@
                    :last-test nil}
    :on-repl-file-loaded-fns []
    :on-repl-evaluated-fns []
+   :on-test-failed-fns-by-key {}
+   :on-test-succeeded-fns-by-key {}
    :ops {}})
 
-(defonce ^:private db* (atom {:projects {}
-                              :on-test-failed-fns-by-key {}
-                              :on-test-succeeded-fns-by-key {}}))
+(defonce ^:private db* (atom {:projects {}}))
 
 (defn get-in
   ([project fields]
@@ -35,20 +35,11 @@
   ([^Project project fields default]
    (clojure.core/get-in @db* (concat [:projects (.getBasePath project)] fields) default)))
 
-(defn global-get-in
-  ([fields]
-   (global-get-in fields nil))
-  ([fields default]
-   (clojure.core/get-in @db* fields default)))
-
 (defn assoc-in! [^Project project fields value]
   (swap! db* clojure.core/assoc-in (concat [:projects (.getBasePath project)] fields) value))
 
 (defn update-in! [^Project project fields fn]
   (swap! db* clojure.core/update-in (concat [:projects (.getBasePath project)] fields) fn))
-
-(defn global-update-in [fields value]
-  (swap! db* clojure.core/update-in fields value))
 
 (defn init-db-for-project [^Project project]
   (swap! db* update :projects (fn [projects]

--- a/src/main/clojure/com/github/clojure_repl/intellij/tests.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/tests.clj
@@ -39,7 +39,7 @@
                      (ui.repl/append-result-text project (db/get-in project [:console :ui]) err))
            :on-failed (fn [result]
                         ;; TODO highlight errors on editor
-                        (doseq [[key fns] (db/global-get-in [:on-test-failed-fns-by-key])]
+                        (doseq [[key fns] (db/get-in project [:on-test-failed-fns-by-key])]
                           (doseq [fn fns]
                             (fn project key result))))
            :on-succeeded (fn [{{:keys [ns test var fail error]} :summary results :results elapsed-time :elapsed-time :as response}]
@@ -58,7 +58,7 @@
                                                                         error
                                                                         (or (some->> (:ms elapsed-time) (format " in %s ms"))
                                                                             ".")) :editor editor))
-                               (doseq [[key fns] (db/global-get-in [:on-test-succeeded-fns-by-key])]
+                               (doseq [[key fns] (db/get-in project [:on-test-succeeded-fns-by-key])]
                                  (doseq [fn fns]
                                    (fn project key response))))}))}))))))
 

--- a/src/main/clojure/com/github/clojure_repl/intellij/tool_window/repl_test.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/tool_window/repl_test.clj
@@ -163,9 +163,12 @@
     (.setAvailable tool-window false)
     (.hide tool-window)))
 
+(set! *warn-on-reflection* false)
 (defn -init [_ ^ToolWindow tool-window]
-  (db/global-update-in [:on-test-failed-fns-by-key tool-window] #(conj % #'on-test-failed))
-  (db/global-update-in [:on-test-succeeded-fns-by-key tool-window] #(conj % #'on-test-succeeded)))
+  (let [project (.getProject tool-window)]
+    (db/update-in! project [:on-test-failed-fns-by-key tool-window] #(conj % #'on-test-failed))
+    (db/update-in! project [:on-test-succeeded-fns-by-key tool-window] #(conj % #'on-test-succeeded))))
+(set! *warn-on-reflection* true)
 
 (defn -manager [_ _ _])
 


### PR DESCRIPTION
Fixes #74 

Segregate test-fns by project so each project has its own tool-window avoiding issues.