### PR TITLE
fix: convert mode to keyword to be handled correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bin
 !.clj-kondo/config.edn
 .project
 .settings
+output.calva-repl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix remote config running wrongly as repl-file.
+
 ## 1.6.1
 
 - Fix error when running tests after open multiple projects

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/remote.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/remote.clj
@@ -20,7 +20,7 @@
 (set! *warn-on-reflection* false)
 (defn ^:private nrepl-host [configuration] (.getNreplHost (.getOptions configuration)))
 (defn ^:private nrepl-port [configuration] (.getNreplPort (.getOptions configuration)))
-(defn ^:private mode [configuration] (.getProject (.getOptions configuration)))
+(defn ^:private mode [configuration] (keyword (.getMode (.getOptions configuration))))
 (set! *warn-on-reflection* true)
 
 (def ^:private options-class ReplRemoteRunOptions)

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/settings_editor/remote.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/settings_editor/remote.clj
@@ -74,7 +74,7 @@
 (defn -resetEditorFrom [this configuration]
   (let [ui @(.state this)
         options (.getOptions configuration)
-        mode (name (.getMode options))]
+        mode (keyword (.getMode options))]
     (if (= :manual-config mode)
       (do
         (seesaw/config! (seesaw/select ui [:#manual]) :selected? true)


### PR DESCRIPTION
The plugin was handling wrongly the `mode` for remote configurations, causing the UI to be different from what was really running.
Discovered this trying to reproduce #95 