### PR TITLE
Fix corner case that may cause build-plugin to fail

### DIFF
--- a/src/main/clojure/com/github/clojure_repl/intellij/tool_window/repl_test.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/tool_window/repl_test.clj
@@ -43,10 +43,11 @@
        (some #(and (.isFile ^File %) (.endsWith (str %) ".clj")))
        boolean))
 
-(def ^:private test-result-type->color
-  {:pass ui.color/normal-foreground
-   :fail ui.color/fail-foreground
-   :error ui.color/error-foreground})
+(defn ^:private test-result-type->color [type]
+  (get {:pass (ui.color/normal-foreground)
+        :fail ui.color/fail-foreground
+        :error ui.color/error-foreground}
+       type))
 
 (defn ^:private label [key value]
   ;; TODO support ANSI colors for libs like matcher-combinators pretty prints.
@@ -95,7 +96,7 @@
                                         :foreground (test-result-type->color (keyword type)))
                           (seesaw/label :text " in ")
                           (ActionLink. ^String var (proxy+ [] java.awt.event.ActionListener
-                                                           (actionPerformed [_ _] (navigate-to-test project test))))]) "span"]
+                                                     (actionPerformed [_ _] (navigate-to-test project test))))]) "span"]
                        (when (seq context) [(seesaw/label :text (str context)) "span"])
                        (when (seq message) [(seesaw/label :text (str message)) "span"])
                        (when (seq expected)

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/color.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/color.clj
@@ -7,7 +7,7 @@
 
 (set! *warn-on-reflection* true)
 
-(def normal-foreground (UIUtil/getToolTipForeground))
+(defn normal-foreground [] (UIUtil/getToolTipForeground))
 (def fail-foreground JBColor/RED)
 (def error-foreground JBColor/RED)
 (def editor-background-color (JBColor/background))


### PR DESCRIPTION
it's not a good idea run IntelliJ code during `def` blocks, as they are evaluated during compile time and intellij classers may depend on intellij runtime.

This may cause build-plugin to fail depending on SO/intellij version:
```java
java.lang.Throwable: Must be precomputed                                                                                                                        
        at com.intellij.openapi.diagnostic.Logger.error(Logger.java:376)                                                                                        
        at com.intellij.ui.scale.JBUIScale.computeSystemScaleFactor(JBUIScale.kt:208)                                                                           
        at com.intellij.ui.scale.JBUIScale$systemScaleFactor$1.invoke(JBUIScale.kt:83)                                                                          
        at com.intellij.ui.scale.JBUIScale$systemScaleFactor$1.invoke(JBUIScale.kt:82)                                                                          
        at com.intellij.util.concurrency.SynchronizedClearableLazy._get_value_$lambda$1$lambda$0(SynchronizedClearableLazy.kt:41)                               
        at java.base/java.util.concurrent.atomic.AtomicReference.updateAndGet(AtomicReference.java:210)                                                         
        at com.intellij.util.concurrency.SynchronizedClearableLazy.getValue(SynchronizedClearableLazy.kt:40)                                                    
        at com.intellij.ui.scale.JBUIScale$userScaleFactor$1.invoke(JBUIScale.kt:39)                                                                            
        at com.intellij.ui.scale.JBUIScale$userScaleFactor$1.invoke(JBUIScale.kt:38)                                                                            
        at com.intellij.util.concurrency.SynchronizedClearableLazy._get_value_$lambda$1$lambda$0(SynchronizedClearableLazy.kt:41)                               
        at java.base/java.util.concurrent.atomic.AtomicReference.updateAndGet(AtomicReference.java:210)                                                         
        at com.intellij.util.concurrency.SynchronizedClearableLazy.getValue(SynchronizedClearableLazy.kt:40)                                                    
        at com.intellij.ui.scale.JBUIScale.scale(JBUIScale.kt:370)                                                                                              
        at com.intellij.util.ui.JBUI.scale(JBUI.java:79)                                                                                                        
        at com.intellij.util.ui.JBInsets.<init>(JBInsets.java:48)                                                                                               
        at com.intellij.util.ui.JBInsets.create(JBInsets.java:117)                                                                                              
        at com.intellij.util.ui.UIUtil.getRegularPanelInsets(UIUtil.java:1059)                                    
```