### PR TITLE
Add history eval to repl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix exception on settings page.
 - Fix special form evaluations. #135
 - Add support for JVM args on local REPL configuration. #124
+- Send to REPL eval results. #92
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fix special form evaluations. #135
 - Add support for JVM args on local REPL configuration. #124
 - Send to REPL eval results. #92
+- Fix repl input when evaluated the same input of last eval.
+- Fix history navigation via shortcut not working after 2.0.0.
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 ## [Unreleased]
 
+- Send to REPL eval results. #92
+- Fix repl input when evaluated the same input of last eval.
+- Fix history navigation via shortcut not working after 2.0.0.
+
 ## 2.3.0
 
 - Update repl window ns after switching ns.
 - Fix exception on settings page.
 - Fix special form evaluations. #135
 - Add support for JVM args on local REPL configuration. #124
-- Send to REPL eval results. #92
-- Fix repl input when evaluated the same input of last eval.
-- Fix history navigation via shortcut not working after 2.0.0.
 
 ## 2.2.0
 

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/eval.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/eval.clj
@@ -22,7 +22,7 @@
 
 (defn ^:private send-result-to-repl [^AnActionEvent event text prefix?]
   (ui.repl/append-result-text
-   (.getProject ^Editor (.getData event CommonDataKeys/EDITOR_EVEN_IF_INACTIVE))
+   (actions/action-event->project event)
    (str (if prefix? "=> " "") text "\n")
    :keep-input? true))
 

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/eval.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/eval.clj
@@ -21,10 +21,9 @@
 (set! *warn-on-reflection* true)
 
 (defn ^:private send-result-to-repl [^AnActionEvent event text prefix?]
-  (ui.repl/append-result-text
+  (ui.repl/append-output
    (actions/action-event->project event)
-   (str (if prefix? "=> " "") text "\n")
-   :keep-input? true))
+   (str "\n" (if prefix? "=> " "") text)))
 
 (defn ^:private eval-action
   [& {:keys [^AnActionEvent event loading-msg eval-fn success-msg-fn post-success-fn inlay-hint-feedback?]
@@ -116,7 +115,7 @@
 
 (defn clear-repl-output-action [^AnActionEvent event]
   (let [project (actions/action-event->project event)]
-    (ui.repl/clear-repl project (db/get-in project [:console :ui]))))
+    (ui.repl/clear-repl project)))
 
 (defn history-up-action [^AnActionEvent event]
   (-> event
@@ -141,7 +140,7 @@
    :success-msg-fn (fn [response]
                      (string/join "\n" (:value response)))
    :post-success-fn (fn [_response]
-                      (ui.repl/append-result-text (.getProject ^Editor (.getData event CommonDataKeys/EDITOR_EVEN_IF_INACTIVE)) ""))))
+                      (ui.repl/clear-input (actions/action-event->project event)))))
 
 (defn refresh-all-action [^AnActionEvent event]
   (let [msg "Refreshed all sucessfully"]

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
@@ -43,7 +43,7 @@
                                         project
                                         {:on-eval (fn [code]
                                                     (nrepl/eval {:project project :code code}))}))
-  (ui.repl/set-text (seesaw/select (db/get-in project [:console :ui]) [:#repl-content]) loading-text {:append? true})
+  (ui.repl/set-text project (seesaw/select (db/get-in project [:console :ui]) [:#repl-content]) loading-text {:append? true})
   (proxy+ [] ConsoleView
     (getComponent [_] (db/get-in project [:console :ui]))
     (getPreferredFocusableComponent [_] (db/get-in project [:console :ui]))

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
@@ -69,6 +69,9 @@
   (when out
     (ui.repl/append-output project (str "\n" out))))
 
+(defn ^:private on-ns-changed [project _]
+  (ui.repl/clear-input project))
+
 (defn ^:private trigger-ui-update
   "IntelliJ actions status (visibility/enable) depend on IntelliJ calls an update of the UI
    but the call of update is not guaranteed. This function triggers the update of the UI.
@@ -101,4 +104,5 @@
     (ui.repl/set-repl-started-initial-text project
                                            (db/get-in project [:console :ui])
                                            (str (initial-repl-text project) extra-initial-text))
-    (db/update-in! project [:on-repl-evaluated-fns] #(conj % on-repl-evaluated trigger-ui-update))))
+    (db/update-in! project [:on-repl-evaluated-fns] #(conj % on-repl-evaluated trigger-ui-update))
+    (db/update-in! project [:on-ns-changed-fns] #(conj % on-ns-changed trigger-ui-update))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
@@ -3,8 +3,7 @@
    [com.github.clojure-repl.intellij.db :as db]
    [com.github.clojure-repl.intellij.nrepl :as nrepl]
    [com.github.clojure-repl.intellij.ui.repl :as ui.repl]
-   [com.rpl.proxy-plus :refer [proxy+]]
-   [seesaw.core :as seesaw])
+   [com.rpl.proxy-plus :refer [proxy+]])
   (:import
    [com.intellij.execution.ui ConsoleView]
    [com.intellij.ide ActivityTracker]
@@ -43,7 +42,7 @@
                                         project
                                         {:on-eval (fn [code]
                                                     (nrepl/eval {:project project :code code}))}))
-  (ui.repl/set-text project (seesaw/select (db/get-in project [:console :ui]) [:#repl-content]) loading-text {:append? true})
+  (ui.repl/append-output project loading-text)
   (proxy+ [] ConsoleView
     (getComponent [_] (db/get-in project [:console :ui]))
     (getPreferredFocusableComponent [_] (db/get-in project [:console :ui]))
@@ -66,9 +65,9 @@
 
 (defn ^:private on-repl-evaluated [project {:keys [out err]}]
   (when err
-    (ui.repl/append-result-text project err))
+    (ui.repl/append-output project (str "\n" err)))
   (when out
-    (ui.repl/append-result-text project out)))
+    (ui.repl/append-output project (str "\n" out))))
 
 (defn ^:private trigger-ui-update
   "IntelliJ actions status (visibility/enable) depend on IntelliJ calls an update of the UI
@@ -82,14 +81,14 @@
   (db/assoc-in! project [:console :process-handler] nil)
   (db/assoc-in! project [:console :ui] nil)
   (db/assoc-in! project [:current-nrepl] nil)
-  (db/update-in! project [:on-repl-evaluated-fns] (fn [fns] (remove #(= on-repl-evaluated %) fns))))
+  (db/update-in! project [:on-repl-evaluated-fns] (fn [fns] (remove #(contains? #{on-repl-evaluated trigger-ui-update} %) fns))))
 
 (defn repl-started [project extra-initial-text]
   (nrepl/start-client!
    :project project
    :on-receive-async-message (fn [msg]
                                (when (:out msg)
-                                 (ui.repl/append-result-text project (:out msg)))))
+                                 (ui.repl/append-output project (:out msg)))))
   (nrepl/clone-session project)
   (nrepl/eval {:project project :code "*ns*"})
   (let [description (nrepl/describe project)]
@@ -99,5 +98,7 @@
     (db/assoc-in! project [:current-nrepl :versions] (:versions description))
     (db/assoc-in! project [:current-nrepl :entry-history] '())
     (db/assoc-in! project [:current-nrepl :entry-index] -1)
-    (ui.repl/set-initial-text project (db/get-in project [:console :ui]) (str (initial-repl-text project) extra-initial-text))
+    (ui.repl/set-repl-started-initial-text project
+                                           (db/get-in project [:console :ui])
+                                           (str (initial-repl-text project) extra-initial-text))
     (db/update-in! project [:on-repl-evaluated-fns] #(conj % on-repl-evaluated trigger-ui-update))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/local.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/local.clj
@@ -67,7 +67,7 @@
                                  (db/assoc-in! project [:current-nrepl :nrepl-host] host)
                                  (db/assoc-in! project [:current-nrepl :nrepl-port] port)
                                  (config.factory.base/repl-started project (repl-started-initial-text command-str)))
-                               (ui.repl/set-text (seesaw/select (db/get-in project [:console :ui]) [:#repl-content]) (.getText event) {:append? true})))
+                               (ui.repl/set-text project (seesaw/select (db/get-in project [:console :ui]) [:#repl-content]) (.getText event) {:append? true})))
                            (processWillTerminate [_ _ _] (config.factory.base/repl-disconnected project))))
     (logger/info "Starting nREPL process:" command-str)
     handler))

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/local.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/local.clj
@@ -8,8 +8,7 @@
    [com.github.clojure-repl.intellij.repl-command :as repl-command]
    [com.github.clojure-repl.intellij.ui.repl :as ui.repl]
    [com.github.ericdallo.clj4intellij.logger :as logger]
-   [com.rpl.proxy-plus :refer [proxy+]]
-   [seesaw.core :as seesaw])
+   [com.rpl.proxy-plus :refer [proxy+]])
   (:import
    [com.github.clojure_repl.intellij.configuration ReplLocalRunOptions]
    [com.intellij.execution.configurations
@@ -67,7 +66,7 @@
                                  (db/assoc-in! project [:current-nrepl :nrepl-host] host)
                                  (db/assoc-in! project [:current-nrepl :nrepl-port] port)
                                  (config.factory.base/repl-started project (repl-started-initial-text command-str)))
-                               (ui.repl/set-text project (seesaw/select (db/get-in project [:console :ui]) [:#repl-content]) (.getText event) {:append? true})))
+                               (ui.repl/append-output project (.getText event))))
                            (processWillTerminate [_ _ _] (config.factory.base/repl-disconnected project))))
     (logger/info "Starting nREPL process:" command-str)
     handler))

--- a/src/main/clojure/com/github/clojure_repl/intellij/db.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/db.clj
@@ -9,7 +9,8 @@
 
 (def ^:private empty-project
   {:project nil
-   :console {:state {:last-output nil
+   :console {:state {:last-output ""
+                     :last-input nil
                      :initial-text nil
                      :status nil}
              :process-handler nil
@@ -56,6 +57,7 @@
   (require '[clojure.pprint :as pp])
   (defn db-p [] (second (first  (second (first @db*)))))
   (def p (:project (db-p)))
+  (db/assoc-in! p [:on-repl-evaluated-fns] [])
 
   (assoc-in! p [:ops] {})
   (pp/pprint (:ops (db-p))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/db.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/db.clj
@@ -24,6 +24,7 @@
                    :last-test nil}
    :on-repl-file-loaded-fns []
    :on-repl-evaluated-fns []
+   :on-ns-changed-fns []
    :on-test-failed-fns-by-key {}
    :on-test-succeeded-fns-by-key {}
    :ops {}})
@@ -57,7 +58,10 @@
   (require '[clojure.pprint :as pp])
   (defn db-p [] (second (first  (second (first @db*)))))
   (def p (:project (db-p)))
-  (db/assoc-in! p [:on-repl-evaluated-fns] [])
+
+  (:state (:console (db-p)))
+  (:ns (:current-nrepl (db-p)))
 
   (assoc-in! p [:ops] {})
+  (assoc-in! p [:on-ns-changed-fns] [])
   (pp/pprint (:ops (db-p))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
@@ -79,7 +79,8 @@
 (defn eval [& {:keys [^Project project ns code]}]
   (let [ns (or ns (db/get-in project [:current-nrepl :ns]) "user")
         {:keys [ns] :as response} @(send-msg project {:op "eval" :code code :ns ns :session (db/get-in project [:current-nrepl :session-id])})]
-    (when (not= ns (db/get-in project [:current-nrepl :ns]))
+    (when (and ns
+               (not= ns (db/get-in project [:current-nrepl :ns])))
       (db/assoc-in! project [:current-nrepl :ns] ns)
       (doseq [fn (db/get-in project [:on-ns-changed-fns])]
         (fn project response)))

--- a/src/main/clojure/com/github/clojure_repl/intellij/tests.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/tests.clj
@@ -34,9 +34,9 @@
                                 (fn []
                                   (ui.hint/show-error :message (format "No namespace '%s' found. Did you load the file?" ns) :editor editor))}))
            :on-out (fn [out]
-                     (ui.repl/append-result-text project out))
+                     (ui.repl/append-output project out))
            :on-err (fn [err]
-                     (ui.repl/append-result-text project err))
+                     (ui.repl/append-output project err))
            :on-failed (fn [result]
                         ;; TODO highlight errors on editor
                         (doseq [[key fns] (db/get-in project [:on-test-failed-fns-by-key])]

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
@@ -20,40 +20,49 @@
 
 (set! *warn-on-reflection* true)
 
-(defn ^:private replace-last [s target replacement]
-  (let [idx (string/last-index-of s target)]
-    (if (nil? idx)
-      s
-      (str (subs s 0 idx) replacement (subs s (+ idx (count target)))))))
+(defn ^:private extract-input+code-to-eval [cur-ns ^String repl-content-text]
+  (let [input (str cur-ns "> ")]
+    (or (when-let [input+eval-text (some->> (re-seq (re-pattern (str cur-ns "> .*")) repl-content-text)
+                                            last
+                                            (string/last-index-of repl-content-text)
+                                            (subs repl-content-text))]
+          [input (string/trim-newline (string/replace input+eval-text input ""))])
+        [input ""])))
 
-(def ^:private code-to-eval-regexp
-  #"(?mx)                    # match multiline and allow comments
-    (^[\w-.]+>\s*)        # group1: match the prompt
-    ([\s\S]*?)               # group2: match entry
-                             # - we use [\s\S] instead of . because . does not match newlines
-    (?=\n^[\w-.]+>\s*|\z) # lookahead for next prompt or end of string")
+(defn ^:private refresh-repl-text
+  [^Project project]
+  (let [repl-content ^EditorTextField (seesaw/select (db/get-in project [:console :ui]) [:#repl-content])
+        input-text (db/get-in project [:console :state :last-input])
+        output-text (db/get-in project [:console :state :last-output])
+        final-text (if input-text
+                     (str output-text "\n" input-text)
+                     output-text)]
+    (app-manager/invoke-later!
+     {:invoke-fn (fn [] (.setText repl-content final-text))})))
 
-(defn ^:private extract-code-to-eval [repl-content-text]
-  (or (some-> (re-seq code-to-eval-regexp repl-content-text)
-              last
-              last
-              string/trim)
-      ""))
+(defn ^:private set-output
+  [^Project project output-text]
+  (db/assoc-in! project [:console :state :last-output] (ui.text/remove-ansi-color output-text))
+  (refresh-repl-text project))
 
-(defn set-text
-  ([^Project project repl-content text]
-   (set-text project repl-content text nil))
-  ([^Project project  ^EditorTextField repl-content text {:keys [append? drop-last-newline-before-append? sync-db-last-output?] 
-                                                          :or {sync-db-last-output? true}}]
-   (let [text (ui.text/remove-ansi-color text)
-         dropped-text (if (and append? drop-last-newline-before-append?)
-                        (replace-last (.getText repl-content) "\n" "")
-                        (.getText repl-content))
-         text (if append? (str dropped-text text) text)]
-     (app-manager/invoke-later! {:invoke-fn (fn []
-                                              (when sync-db-last-output?
-                                                (db/assoc-in! project [:console :state :last-output] text))
-                                              (.setText repl-content text))}))))
+(defn append-output
+  [^Project project append-text]
+  (let [last-output (db/get-in project [:console :state :last-output])]
+    (set-output project (str last-output append-text))))
+
+(defn ^:private set-temp-input
+  [^Project project temp-input]
+  (let [repl-content ^EditorTextField (seesaw/select (db/get-in project [:console :ui]) [:#repl-content])
+        input-text (db/get-in project [:console :state :last-input])
+        output-text (db/get-in project [:console :state :last-output])
+        final-text (str output-text "\n" input-text temp-input)]
+    (app-manager/invoke-later!
+     {:invoke-fn (fn [] (.setText repl-content final-text))})))
+
+(defn clear-input [project]
+  (let [ns-text (str (db/get-in project [:current-nrepl :ns]) "> ")]
+    (db/assoc-in! project [:console :state :last-input] ns-text)
+    (refresh-repl-text project)))
 
 (defn ^:private move-caret-and-scroll-to-latest [^EditorTextField repl-content]
   (app-manager/invoke-later!
@@ -66,24 +75,19 @@
   (.consume event)
   (let [repl-content ^EditorTextField (seesaw/select (db/get-in project [:console :ui]) [:#repl-content])
         repl-content-text (.getText repl-content)
-        code-to-eval (extract-code-to-eval repl-content-text)
+        cur-ns (db/get-in project [:current-nrepl :ns])
+        [input code-to-eval] (extract-input+code-to-eval cur-ns repl-content-text)
         entries (db/get-in project [:current-nrepl :entry-history])]
     (db/assoc-in! project [:current-nrepl :entry-index] -1)
     (when-not (or (string/blank? code-to-eval)
                   (= code-to-eval (first entries)))
       (db/update-in! project [:current-nrepl :entry-history] #(conj % code-to-eval)))
-    (let [{:keys [value out err]} (on-eval code-to-eval)
+    (let [{:keys [value]} (on-eval code-to-eval)
           result-text (str
-                       (when err (str "\n" err))
-                       (when out (str "\n" out))
-                       (when value (str "\n=> " (last value))))
-          ns-text (str "\n" (db/get-in project [:current-nrepl :ns]) "> ")
-          new-text (str result-text ns-text)]
-      (set-text project repl-content new-text {:append? true :drop-last-newline-before-append? true})
-      (move-caret-and-scroll-to-latest repl-content)
-      (app-manager/invoke-later!
-       {:invoke-fn (fn []
-                     (db/assoc-in! project [:console :state :last-output] (.getText repl-content)))})))
+                       "\n" input code-to-eval (when value "\n")
+                       (when value (str "=> " (last value))))]
+      (append-output project result-text)
+      (move-caret-and-scroll-to-latest repl-content)))
   true)
 
 (defn history-up
@@ -94,10 +98,9 @@
                (< current-index (dec (count entries))))
       (let [entry (nth entries (inc current-index))
             console (db/get-in project [:console :ui])
-            repl-content (seesaw/select console [:#repl-content])
-            last-output (db/get-in project [:console :state :last-output])]
+            repl-content (seesaw/select console [:#repl-content])]
         (db/update-in! project [:current-nrepl :entry-index] inc)
-        (set-text project repl-content (str last-output entry) {:sync-db-last-output? false})
+        (set-temp-input project entry)
         (move-caret-and-scroll-to-latest repl-content)))))
 
 (defn history-down
@@ -108,40 +111,20 @@
                (> current-index 0))
       (let [entry (nth entries (dec current-index))
             console (db/get-in project [:console :ui])
-            repl-content (seesaw/select console [:#repl-content])
-            last-output (db/get-in project [:console :state :last-output])]
+            repl-content (seesaw/select console [:#repl-content])]
         (db/update-in! project [:current-nrepl :entry-index] dec)
-        (set-text project repl-content (str last-output entry) {:sync-db-last-output? false})
+        (set-temp-input project entry)
         (move-caret-and-scroll-to-latest repl-content)))))
 
-(defn ^:private on-repl-history-entry [project ^KeyEvent key-event]
-  (let [page-up? (= KeyEvent/VK_PAGE_UP (.getKeyCode key-event))
-        page-down? (= KeyEvent/VK_PAGE_DOWN (.getKeyCode key-event))
-        entries (db/get-in project [:current-nrepl :entry-history])]
-    (when (pos? (count entries))
-      (when page-up?
-        (history-up project))
-      (when page-down?
-        (history-down project))))
-  true)
-
 (defn ^:private on-repl-new-line [project]
-  (set-text project (seesaw/select (db/get-in project [:console :ui]) [:#repl-content]) "\n" {:append? true})
+  (append-output project "\n")
   true)
 
-(defn ^:private ns-text [project]
-  (str (db/get-in project [:current-nrepl :ns]) "> "))
-
-(defn ^:private initial-text+ns [project initial-text]
-  (str initial-text "\n\n" (ns-text project)))
-
-(defn clear-repl [^Project project console]
-  (let [text (str ";; Output cleared\n" (ns-text project))]
-    (set-text project (seesaw/select console [:#repl-content]) text)))
+(defn clear-repl [^Project project]
+  (set-output project ";; Output cleared"))
 
 (defn ^:private on-repl-clear [project]
-  (let [console (db/get-in project [:console :ui])]
-    (clear-repl project console))
+  (clear-repl project)
   true)
 
 (defn ^:private on-repl-backspace [project ^KeyEvent event]
@@ -151,14 +134,15 @@
         last-repl-line (last repl-lines)
         repl-input (re-find (re-pattern (str ns "+>\\s")) last-repl-line)]
     (when-not repl-input
-      (set-text project repl-content (str (string/join "\n" (drop-last repl-lines)) "\n" ns "> "))
+      (clear-input project)
       (move-caret-and-scroll-to-latest repl-content)
       (.consume event))))
 
 (defn build-console [project {:keys [initial-text on-eval]}]
-  (db/assoc-in! project [:console :state] {:status :disabled
-                                           :initial-text initial-text
-                                           :last-output ""})
+  (db/assoc-in! project [:console :state :status] :disabled)
+  (db/assoc-in! project [:console :state :initial-text] initial-text)
+  (db/assoc-in! project [:console :state :last-output] "")
+  (db/assoc-in! project [:console :state :last-input] nil)
   (mig/mig-panel
    :id :repl-input-layout
    :constraints ["fill, insets 0"]
@@ -166,7 +150,7 @@
    :items [[(ui.components/clojure-text-field
              :id :repl-content
              :project project
-             :text (db/get-in project [:console :state :last-output])
+             :text ""
              :background-color (.getBackgroundColor (ui.color/repl-window))
              :font (ui.font/code-font (ui.color/repl-window))
              :on-key-pressed (fn [^KeyEvent event]
@@ -175,12 +159,8 @@
                                        shift? (not= 0 (bit-and (.getModifiers event) InputEvent/SHIFT_MASK))
                                        enter? (= KeyEvent/VK_ENTER (.getKeyCode event))
                                        backspace? (= KeyEvent/VK_BACK_SPACE (.getKeyCode event))
-                                       l? (= KeyEvent/VK_L (.getKeyCode event))
-                                       page-up? (= KeyEvent/VK_PAGE_UP (.getKeyCode event))
-                                       page-down? (= KeyEvent/VK_PAGE_DOWN (.getKeyCode event))]
+                                       l? (= KeyEvent/VK_L (.getKeyCode event))]
                                    (cond
-                                     (or (and ctrl? page-up?) (and ctrl? page-down?))
-                                     (on-repl-history-entry project event)
 
                                      (and shift? enter?)
                                      (on-repl-new-line project)
@@ -196,14 +176,15 @@
                                  false)))
             "grow"]]))
 
-(defn set-initial-text [project console text]
-  (db/assoc-in! project [:console :state] {:status :enabled
-                                           :initial-text text
-                                           :last-output (initial-text+ns project text)})
-  (let [ns-text (str "\n\n" (db/get-in project [:current-nrepl :ns]) "> ")
+(defn set-repl-started-initial-text [project console text]
+  (let [output (str text "\n")
         repl-content (seesaw/select console [:#repl-content])]
+    (db/assoc-in! project [:console :state :status] :enabled)
+    (db/assoc-in! project [:console :state :initial-text] text)
     (ui.components/init-clojure-text-field! repl-content)
-    (set-text project repl-content (str text ns-text) {:append? true})
+    (append-output project output)
+    (clear-input project)
+    (refresh-repl-text project)
     (move-caret-and-scroll-to-latest repl-content)))
 
 (def ^:private ^DateTimeFormatter time-formatter (DateTimeFormatter/ofPattern "dd/MM/yyyy HH:mm:ss"))
@@ -211,19 +192,8 @@
 (defn close-console [project console]
   (let [repl-content ^EditorTextField (seesaw/select console [:#repl-content])]
     (db/assoc-in! project [:console :state :status] :disabled)
+    (db/assoc-in! project [:console :state :last-input] nil)
     (.setViewer repl-content false)
-    (set-text project (seesaw/select console [:#repl-content]) (format "\n*** Closed on %s ***" (.format time-formatter (java.time.LocalDateTime/now))) {:append? true})
+    (append-output project
+                   (format "\n*** Closed on %s ***" (.format time-formatter (java.time.LocalDateTime/now))))
     (key-manager/unregister-listener-for-editor! (.getEditor repl-content))))
-
-(defn append-result-text [project text & {:keys [keep-input?]}]
-  (let [console (db/get-in project [:console :ui])
-        ui ^EditorTextField (seesaw/select console [:#repl-content])]
-    (if keep-input?
-      (let [repl-lines (clojure.string/split-lines (.getText ui))
-            repl-input (last repl-lines)
-            repl-without-input (clojure.string/join "\n" (butlast repl-lines))]
-        (set-text project ui (str repl-without-input "\n" text repl-input)))
-      (set-text project 
-                ui
-                (str "\n" text (db/get-in project [:current-nrepl :ns]) "> ")
-                {:append? true}))))

--- a/src/test/clojure/com/github/clojure_repl/intellij/ui/repl_test.clj
+++ b/src/test/clojure/com/github/clojure_repl/intellij/ui/repl_test.clj
@@ -8,46 +8,63 @@
   (string/join "\n" strings))
 
 (deftest extract-code-to-eval-test
-  (is (= "(+ 2 3)"
-         (#'ui.repl/extract-code-to-eval (code ";; some text here"
-                                               "user> (+ 1 2)"
-                                               ";; => 1"
-                                               "user> (+ 2 3)"))))
-  (is (= "(tap> 1)"
-         (#'ui.repl/extract-code-to-eval (code ";; some text here"
-                                               "user> 1"
-                                               ";; => 1"
-                                               "user> (tap> 1)"))))
-  (is (= "(tap> 1)"
-         (#'ui.repl/extract-code-to-eval (code ";; some text here"
-                                               "user-bar.baz> 1"
-                                               ";; => 1"
-                                               "user-bar.baz> (tap> 1)"))))
-  (is (= (code "(defn foo []"
-               "                123)")
-         (#'ui.repl/extract-code-to-eval (code ";; some text here"
-                                               "user-bar.baz> 1"
-                                               ";; => 1"
-                                               "user-bar.baz> (defn foo []"
-                                               "                123)"))))
-  (is (= (code  "(defn foo []"
-                "        (tap> 123)"
-                "        123)")
-         (#'ui.repl/extract-code-to-eval (code ";; some text here"
-                                               "user> 1"
-                                               ";; => 1"
-                                               "user> (defn foo []"
-                                               "        (tap> 123)"
-                                               "        123)"))))
-  (is (= (code  "(defn foo []"
-                "                (tap> 123)"
-                "                123)")
-         (#'ui.repl/extract-code-to-eval (code ";; some text here"
-                                               "user-bar.baz> 1"
-                                               ";; => 1"
-                                               "user-bar.baz> (defn foo []"
-                                               "                (tap> 123)"
-                                               "                123)")))))
+  (is (= ["user> " "(+ 2 3)"]
+         (#'ui.repl/extract-input+code-to-eval "user"
+                                               (code ";; some text here"
+                                                     "user> (+ 1 2)"
+                                                     ";; => 1"
+                                                     "user> (+ 2 3)"))))
+  (is (= ["user> " "(tap> 1)"]
+         (#'ui.repl/extract-input+code-to-eval "user"
+                                               (code ";; some text here"
+                                                     "user> 1"
+                                                     ";; => 1"
+                                                     "user> (tap> 1)"))))
+  (is (= ["user-bar.baz> " "(tap> 1)"]
+         (#'ui.repl/extract-input+code-to-eval "user-bar.baz"
+                                               (code ";; some text here"
+                                                     "user-bar.baz> 1"
+                                                     ";; => 1"
+                                                     "user-bar.baz> (tap> 1)"))))
+  (is (= ["user-bar.baz> " (code "(defn foo []"
+                                 "                123)")]
+         (#'ui.repl/extract-input+code-to-eval "user-bar.baz"
+                                               (code ";; some text here"
+                                                     "user-bar.baz> 1"
+                                                     ";; => 1"
+                                                     "user-bar.baz> (defn foo []"
+                                                     "                123)"))))
+  (is (= ["user> " (code "(defn foo []"
+                         "        (tap> 123)"
+                         "        123)")]
+         (#'ui.repl/extract-input+code-to-eval "user"
+                                               (code ";; some text here"
+                                                     "user> 1"
+                                                     ";; => 1"
+                                                     "user> (defn foo []"
+                                                     "        (tap> 123)"
+                                                     "        123)"))))
+  (is (= ["user-bar.baz> " (code "(defn foo []"
+                                 "                (tap> 123)"
+                                 "                123)")]
+         (#'ui.repl/extract-input+code-to-eval "user-bar.baz"
+                                               (code ";; some text here"
+                                                     "user-bar.baz> 1"
+                                                     ";; => 1"
+                                                     "user-bar.baz> (defn foo []"
+                                                     "                (tap> 123)"
+                                                     "                123)"))))
+  (is (= ["user-bar.baz> " "(+ 2 3)"]
+         (#'ui.repl/extract-input+code-to-eval "user-bar.baz"
+                                               (code ";; some text here"
+                                                     "user-bar.baz> "
+                                                     "user-bar.baz> (+ 2 3)"))))
+  (is (= ["user> " "(+ 2 3)"]
+         (#'ui.repl/extract-input+code-to-eval "user"
+                                               (code ";; some text here"
+                                                     "user> 1"
+                                                     "=> 1"
+                                                     "user> 1")))))
 
 (comment
   (extract-code-to-eval-test))


### PR DESCRIPTION
Fixes #92 

- All eval actions now send to REPL
- Changed repl window eval to not append a `;;` since now we have syntax coloring, color the result may be good
- Fix repl input when evaluated the same input of last eval.
- Fix history navigation via shortcut not working after 2.0.0.

![2025-02-27_13-47](https://github.com/user-attachments/assets/fe7f3c32-a32d-425f-9ef8-9a25efa1167a)
