### PR TITLE
fix: out messages of REPL where not being sent to REPL window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix REPL output when evaluation generates stdout. #153
+
 ## 2.5.3
 
 - Add client info to clone op for metrics.

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
@@ -88,8 +88,7 @@
   (ui.repl/close-console project (db/get-in project [:console :ui]))
   (db/assoc-in! project [:console :process-handler] nil)
   (db/assoc-in! project [:console :ui] nil)
-  (db/assoc-in! project [:current-nrepl] nil)
-  #_(db/update-in! project [:on-repl-evaluated-fns] (fn [fns] (remove #(contains? #{on-repl-evaluated trigger-ui-update} %) fns))))
+  (db/assoc-in! project [:current-nrepl] nil))
 
 (defn repl-started [project extra-initial-text]
   (nrepl/start-client!
@@ -108,5 +107,4 @@
     (ui.repl/set-repl-started-initial-text project
                                            (db/get-in project [:console :ui])
                                            (str (initial-repl-text project) extra-initial-text))
-    #_(db/update-in! project [:on-repl-evaluated-fns] #(conj % on-repl-evaluated trigger-ui-update))
     (db/update-in! project [:on-ns-changed-fns] #(conj % on-ns-changed trigger-ui-update))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
@@ -89,8 +89,6 @@
 (defn ^:private eval [^Project project ns code]
   (let [session (db/get-in project [:current-nrepl :session-id])
         response @(send-msg project {:op "eval" :code code :ns ns :session session})]
-    #_(doseq [fn (db/get-in project [:on-repl-evaluated-fns])]
-        (fn project response))
     response))
 
 (defn prep-env-for-eval
@@ -168,8 +166,6 @@
                                      :file (.getText (.getDocument editor))
                                      :file-path  (some-> virtual-file .getPath)
                                      :file-name (some-> virtual-file .getName)})]
-    #_(doseq [fn (db/get-in project [:on-repl-evaluated-fns])]
-        (fn project response))
     response))
 
 (defn describe [^Project project]

--- a/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/nrepl.clj
@@ -37,6 +37,7 @@
               (if-let [sent-request (get @sent-messages* id)]
                 (do
                   (swap! received-messages* update id conj resp)
+                  (on-receive-async-message resp)
                   (when (and status (contains? (set status) "done"))
                     (let [responses (get @received-messages* id)]
                       (swap! sent-messages* dissoc id)
@@ -88,8 +89,8 @@
 (defn ^:private eval [^Project project ns code]
   (let [session (db/get-in project [:current-nrepl :session-id])
         response @(send-msg project {:op "eval" :code code :ns ns :session session})]
-    (doseq [fn (db/get-in project [:on-repl-evaluated-fns])]
-      (fn project response))
+    #_(doseq [fn (db/get-in project [:on-repl-evaluated-fns])]
+        (fn project response))
     response))
 
 (defn prep-env-for-eval
@@ -167,8 +168,8 @@
                                      :file (.getText (.getDocument editor))
                                      :file-path  (some-> virtual-file .getPath)
                                      :file-name (some-> virtual-file .getName)})]
-    (doseq [fn (db/get-in project [:on-repl-evaluated-fns])]
-      (fn project response))
+    #_(doseq [fn (db/get-in project [:on-repl-evaluated-fns])]
+        (fn project response))
     response))
 
 (defn describe [^Project project]


### PR DESCRIPTION
Fix how the plugin handle the messages from the connected REPL. Every `:out` message now will be sent to the REPL Console view.

## Before

https://github.com/user-attachments/assets/631c97e3-3bf9-40df-945a-a8b8cb133213


## After


https://github.com/user-attachments/assets/529657b1-2e7a-408c-a7a6-699e3fe31b44

Fixes #153 

## Checklist
 - [x] Added changes in the `Unreleased` section of CHANGELOG.md
