### PR TITLE
move caret every time text is set

### DIFF
--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
@@ -105,6 +105,5 @@
     (db/assoc-in! project [:current-nrepl :ns] "user")
     (db/assoc-in! project [:file->ns] {})
     (ui.repl/set-repl-started-initial-text project
-                                           (db/get-in project [:console :ui])
                                            (str (initial-repl-text project) extra-initial-text))
     (db/update-in! project [:on-ns-changed-fns] #(conj % on-ns-changed trigger-ui-update))))


### PR DESCRIPTION
Bug description:

> Describe the bug
> When interacting with the REPL through Actions, the console does not scroll automatically.
> 
> To Reproduce
> Steps to reproduce the behavior:
> 
> Evaluate a lot of times a code
> Check that when the content of the REPL console window is bigger than the window, it does not scroll automatically
> Expected behavior
> Automatically scroll when new content is added
> 

I was not able to reproduce this behavior when the repl initialize corretly, but when REPL fails to initialize the auto-scroll was really not working.

https://github.com/user-attachments/assets/e468b572-7e4e-4e7f-93df-3e4003c05ef3


https://github.com/user-attachments/assets/221a8db1-ef3b-40b0-830d-4c4f66b2ed99


## Checklist
 - [ ] Added changes in the `Unreleased` section of CHANGELOG.md
