### PR TITLE
Change UI details

### DIFF
--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/base.clj
@@ -80,9 +80,7 @@
   (when (contains? (set status) "done")
     (trigger-ui-update))
   (when err
-    (ui.repl/append-output project (str "\n" err)))
-  (when out
-    (ui.repl/append-output project (str "\n" out))))
+    (ui.repl/append-output project (str "\n" err))))
 
 (defn repl-disconnected [^Project project]
   (ui.repl/close-console project (db/get-in project [:console :ui]))

--- a/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/remote.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/configuration/factory/remote.clj
@@ -67,6 +67,6 @@
            ([executor ^ExecutionEnvironment env]
             (proxy+ [env] CommandLineState
               (createConsole [_ _]
-                (config.factory.base/build-console-view project "Connecting to nREPL server..."))
+                (config.factory.base/build-console-view project "Connecting to nREPL server...\n"))
               (startProcess [_]
                 (setup-process this project))))))))))

--- a/src/main/clojure/com/github/clojure_repl/intellij/extension/register_actions_startup.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/extension/register_actions_startup.clj
@@ -93,13 +93,13 @@
                            :title "Moves up in history"
                            :description "Moves up in history"
                            :icon AllIcons$Actions/PreviousOccurence
-                           :keyboard-shortcut {:first "control PAGE_UP" :replace-all true}
+                           :keyboard-shortcut {:first "UP" :replace-all true}
                            :on-performed #'a.eval/history-up-action)
   (action/register-action! :id "ClojureREPL.HistoryDown"
                            :title "Moves down in history"
                            :description "Moves down in history"
                            :icon AllIcons$Actions/NextOccurence
-                           :keyboard-shortcut {:first "control PAGE_DOWN" :replace-all true}
+                           :keyboard-shortcut {:first "DOWN" :replace-all true}
                            :on-performed #'a.eval/history-down-action)
   (action/register-action! :id "ClojureREPL.Interrupt"
                            :keyboard-shortcut {:first "shift alt R" :second "shift alt S" :replace-all true}

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/color.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/color.clj
@@ -20,9 +20,10 @@
     (when font-type (.setFontType attrs font-type))
     (TextAttributesKey/createTextAttributesKey ^String key attrs)))
 
+
 (defn text-attributes []
   {:repl-window (attr :key "REPL_WINDOW"
-                      :background (JBColor/background))
+                     :background (UIUtil/getWindowColor))
    :eval-inline-hint (attr :key "REPL_EVAL_INLINE_INLAY_HINT"
                            :background (JBColor. (Color/decode "#c7e8fc") (Color/decode "#16598c"))
                            :inherit DebuggerColors/INLINED_VALUES_EXECUTION_LINE)

--- a/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/ui/repl.clj
@@ -79,6 +79,7 @@
                    (.moveToOffset (.getCaretModel editor) (.getTextLength (.getDocument repl-content)))
                    (.scrollToCaret (.getScrollingModel editor) ScrollType/MAKE_VISIBLE)))}))
 
+
 (defn ^:private on-repl-input [project on-eval ^KeyEvent event]
   (.consume event)
   (let [repl-content ^EditorTextField (seesaw/select (db/get-in project [:console :ui]) [:#repl-content])
@@ -90,10 +91,11 @@
     (when-not (or (string/blank? code-to-eval)
                   (= code-to-eval (first entries)))
       (db/update-in! project [:current-nrepl :entry-history] #(conj % code-to-eval)))
-    (let [{:keys [value ns] :as response}  (on-eval code-to-eval)
+    (let [{:keys [value ns out] :as response}  (on-eval code-to-eval)
           result-text (str
-                       "\n" input code-to-eval (when value "\n")
-                       (when value (str "=> " (last value))))]
+                       "\n" input code-to-eval
+                        (when out (str "\n" out))
+                        (when value (str "=> " (last value))))]
       (append-output project result-text)
       (when (and ns (not= ns cur-ns))
         (db/assoc-in! project [:current-nrepl :ns] ns)


### PR DESCRIPTION
## Changes:
- Background of the same color of the window
- Add breakline in REPL initialization output
- Arrow up and down now moves history ->  With this change the repl content is not editable anymore
- The async output of functions now is returned below the input and above the return. 
example: 
<img width="154" alt="image" src="https://github.com/user-attachments/assets/38d5f5c7-0b85-4ead-84c6-cfee2f4ead33" />
  instead of  
<img width="154" alt="image" src="https://github.com/user-attachments/assets/d2582ad6-b7ab-447d-ae8f-0b5034d06b75" />



## Checklist
 - [ ] Added changes in the `Unreleased` section of CHANGELOG.md
