### PR TITLE
fix parser to check only symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix parser to handle namespaced def forms like `s/deftest` in `find-var-at-pos` function
+
 ## 2.6.0
 
 - Add Custom Code Actions feature, enabling the user to define custom code snippets to be executed as an action.

--- a/src/main/clojure/com/github/clojure_repl/intellij/parser.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/parser.clj
@@ -74,8 +74,12 @@
 
     ;; We check if the form starts with "def" to ensure it's a var definition
     ;; This is the most reliable way we found to distinguish between var definitions
-    ;; and other forms, as it covers all def-like forms (def, defn, defmacro, etc.)
-    (not (clojure.string/starts-with? (z/string loc) "def"))
+    ;; and other forms, as it covers all def-like forms (def, defn, defmacro, etc.) 
+    (let [form-str (z/string loc)
+          symbol-name (if (clojure.string/includes? form-str "/")
+                        (last (clojure.string/split form-str #"/"))
+                        form-str)]
+      (not (clojure.string/starts-with? symbol-name "def")))
     nil
 
     (= :map (-> loc z/next z/tag))

--- a/src/test/clojure/com/github/clojure_repl/intellij/parser_test.clj
+++ b/src/test/clojure/com/github/clojure_repl/intellij/parser_test.clj
@@ -1,0 +1,29 @@
+(ns com.github.clojure-repl.intellij.parser-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [com.github.clojure-repl.intellij.parser :as parser]
+   [rewrite-clj.zip :as z]))
+
+(deftest find-var-at-pos-test
+  (testing "should find var name in deftest form"
+    (let [zloc (z/of-string "(deftest a 1)")]
+      (is (= "a" (-> (parser/find-var-at-pos zloc 1 4) z/string))
+          "find-var-at-pos should return 'a' for (deftest a 1)")))
+
+  (testing "should find var name in s/deftest form"
+    (let [zloc (z/of-string "(s/deftest a 1)")]
+      (is (= "a" (-> (parser/find-var-at-pos zloc 1 4) z/string))
+          "find-var-at-pos should return 'a' for (s/deftest a 1)")))
+
+  (testing "should handle other def-like forms"
+    (let [defn-zloc (z/of-string "(defn my-function [] 1)")
+          def-zloc (z/of-string "(def my-var 42)")]
+      (is (= "my-function" (-> (parser/find-var-at-pos defn-zloc 1 4) z/string))
+          "find-var-at-pos should return 'my-function' for (defn my-function [] 1)")
+      (is (= "my-var" (-> (parser/find-var-at-pos def-zloc 1 4) z/string))
+          "find-var-at-pos should return 'my-var' for (def my-var 42)")))
+
+  (testing "should return nil for non-def forms"
+    (let [zloc (z/of-string "(+ 1 2)")]
+      (is (nil? (parser/find-var-at-pos zloc 1 2))
+          "find-var-at-pos should return nil for non-def forms"))))


### PR DESCRIPTION
Fix parser to handle namespaced def forms like s/deftest

**Problem**
The `find-var-at-pos` function failed to identify variable names in namespaced def forms like `(s/deftest a 1)` because it was checking if the form string started with "def", but namespaced forms start with the namespace prefix.  

**Solution**
Updated `var-name-loc-from-op` to extract the symbol name by splitting on "/" and checking if the symbol name (not the full form) starts with "def".


```clojure
;; Before: Failed
(-> (find-var-at-pos (z/of-string "(s/deftest a 1)") 1 4) z/string)
;; => nil

;; After: Works correctly
(-> (find-var-at-pos (z/of-string "(s/deftest a 1)") 1 4) z/string)
;; => "a"
```

## Checklist
 - [x] Added changes in the `Unreleased` section of CHANGELOG.md
