### PR TITLE
fix: Custom Code Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix Custom Code Action not working in new versions of IntelliJ (2025)
+
 ## 2.6.2
 
 - Fix Custom Code Action not working in new versions of IntelliJ (2025)

--- a/src/main/clojure/com/github/clojure_repl/intellij/action/custom_code_actions.clj
+++ b/src/main/clojure/com/github/clojure_repl/intellij/action/custom_code_actions.clj
@@ -49,7 +49,11 @@
    This function checks in runtime the version before call"
   [^DefaultActionGroup group]
   (if (app-info/at-least-version? "252.13776.59")
-    (.getChildren group ^ActionManager (ActionManager/getInstance))
+    ;; For some reason, using getChildren (ActionManager) does not work when building the plugin
+    ;; It always try to call getChildren (AnActionEvent) and throws error.
+    ;; Maybe is losing the type hint during the build, because evaluating the same code works.
+    ;; For now, we are calling getChildActionsOrStubs
+    (.getChildActionsOrStubs group)
     (.getChildren group nil ^ActionManager (ActionManager/getInstance))))
 (set! *warn-on-reflection* true)
 


### PR DESCRIPTION
The issue with Custom Code Actions and new versions of IntelliJ is that they changed the signature of the `DefaultActionGroup/.getChildren`, so we need to handle both versions.
Using type hint is not working in this case, probably is because when it compiles it uses the min version of IntelliJ library and this version not has the new method signature.

### Code with type hint
It puts type hint as `AnActionEvent`, what is wrong:
```java
   public static Object invokeStatic(Object group) {
      Object var10000 = ((IFn)const__0.getRawRoot()).invoke("252.13776.59");
      AnAction[] var1;
      if (var10000 != null) {
         if (var10000 != Boolean.FALSE) {
            var10000 = group;
            group = null;
            // Wrong cast
            var1 = ((DefaultActionGroup)var10000).getChildren((AnActionEvent)ActionManager.getInstance());
            return var1;
         }
      }

      var10000 = group;
      group = null;
      var1 = ((DefaultActionGroup)var10000).getChildren((AnActionEvent)null, (ActionManager)ActionManager.getInstance());
      return var1;
   }
```

### Using reflection
Using invoke method solves this issue
```java
   public static Object invokeStatic(Object group) {
      Object cls = ((IFn)const__0.getRawRoot()).invoke(group);

      Object var10000;
      Object var3;
      try {
         var10000 = cls;
         cls = null;
         Object m = ((Class)var10000).getMethod((String)"getChildren", (Class[])((IFn)const__1.getRawRoot()).invoke(const__2, const__4));
         Method var5 = m;
         m = null;
         var3 = ((Method)var5).invoke(group, (Object[])((IFn)const__5.getRawRoot()).invoke(Tuple.create(ActionManager.getInstance())));
      } catch (NoSuchMethodException var4) {
         var10000 = group;
         group = null;
         var3 = ((DefaultActionGroup)var10000).getChildren((AnActionEvent)null, (ActionManager)ActionManager.getInstance());
      }

      return var3;
   }
```

## Checklist
 - [x] Added changes in the `Unreleased` section of CHANGELOG.md
